### PR TITLE
ci: auto-create GitHub Release on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,10 @@ on:
   push:
     tags: ['v*']
 permissions:
-  contents: read
+  # `contents: write` is needed for the "Create GitHub Release" step at
+  # the end (uses `gh release create`). Read-only is enough for the
+  # actual npm publish — that's authenticated via NODE_AUTH_TOKEN.
+  contents: write
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -39,3 +42,52 @@ jobs:
               npm publish -w "packages/$pkg" --access public
             fi
           done
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"          # e.g. v0.14.1
+          VERSION="${TAG#v}"                # e.g. 0.14.1
+          CHANGELOG="packages/governance/CHANGELOG.md"
+
+          # Skip if a release already exists for this tag (idempotent re-run).
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "✓ Release $TAG already exists, skipping"
+            exit 0
+          fi
+
+          # Pull the matching `## [VERSION] - DATE — TITLE` header so we can
+          # use the human-readable suffix as the release title. Falls back
+          # to the bare tag if the section isn't found.
+          HEADER=$(grep -E "^## \[$VERSION\]" "$CHANGELOG" | head -1 || true)
+          if [ -n "$HEADER" ]; then
+            TITLE_SUFFIX=$(echo "$HEADER" | sed -E "s/^## \[$VERSION\] - [0-9-]+ — //")
+            RELEASE_TITLE="$TAG — $TITLE_SUFFIX"
+          else
+            RELEASE_TITLE="$TAG"
+          fi
+
+          # Extract the CHANGELOG body for this version: everything between
+          # the version header and the next "## [" header (or end of file).
+          # The header line itself is dropped — the title carries that info.
+          NOTES_FILE=$(mktemp)
+          awk -v v="$VERSION" '
+            $0 ~ "^## \\[" v "\\]" { capture=1; next }
+            /^## \[/ && capture { exit }
+            capture { print }
+          ' "$CHANGELOG" > "$NOTES_FILE"
+
+          if [ ! -s "$NOTES_FILE" ]; then
+            echo "::warning::No CHANGELOG section found for $VERSION; release notes will be empty"
+          fi
+
+          # Pre-1.0 versions are technically prereleases by SemVer, but we
+          # treat 0.x as stable for this SDK and don't want them hidden in
+          # the Releases sidebar — so no --prerelease flag.
+          gh release create "$TAG" \
+            --title "$RELEASE_TITLE" \
+            --notes-file "$NOTES_FILE"
+
+          echo "✓ Created release $TAG"


### PR DESCRIPTION
Releases were falling out of sync — v0.13.1 / v0.13.2 / v0.14.0 / v0.14.1 all had tags + npm publish but no GitHub Release entries until I created them by hand today. Future tags should auto-publish a Release with notes pulled from the matching CHANGELOG section.

Adds a "Create GitHub Release" step at the end of publish.yml:

- Skips if a release for the tag already exists (idempotent re-run safe)
- Pulls the human-readable suffix from the CHANGELOG header line (`## [VERSION] - DATE — TITLE`) and uses it as the release title
- Extracts the body between this version's header and the next `## [` header — same content the CHANGELOG already maintains
- Does NOT mark 0.x as prerelease (we treat 0.x as stable for this SDK)
- Promotes permissions to `contents: write` (was read-only) — npm publish doesn't need it; gh release create does

The script doesn't fail the workflow when no CHANGELOG section is found — emits a `::warning::` so we notice but the npm publish has already happened by that step. We can backfill notes manually after.

## Description

<!-- What does this PR do? -->

## Checklist

- [ ] `npm test` passes (all 945+ tests)
- [ ] `npm run build` compiles clean
- [ ] No `any` types introduced
- [ ] All new files < 300 LOC
- [ ] Documentation updated (if public API changed)
- [ ] Tests added for new functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; main impact is granting `contents: write` to the workflow and adding a release-creation step that could fail due to changelog parsing or GitHub CLI behavior.
> 
> **Overview**
> Automates GitHub release creation as part of the tag-based publish workflow: after successful npm publishing, the workflow now creates a GitHub Release for the tag using notes extracted from `packages/governance/CHANGELOG.md`, and skips creation if the release already exists.
> 
> To enable this, the workflow’s `permissions` are elevated from `contents: read` to **`contents: write`** so `gh release create` can run using `GITHUB_TOKEN` (while npm publishing remains token-authenticated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c7000be513ccc1c7697f2d9f9983317cc115e67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->