### PR TITLE
feat(scan): opt-in multi-modal scan orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,15 @@ is exactly what it does and does not do:
   Tool executions **inside** AWS action groups are opaque — the adapter
   cannot see them, let alone block them. Use `guardToolUse()` to enforce
   at the tool level manually, or push tool calls onto the host side.
-- **Multi-modal content is not scanned by default.** Image, PDF, and audio
-  blocks on Anthropic/Vercel AI/Genkit/LlamaIndex/Bedrock pass through
-  without injection detection in the current release — a vision-enabled
-  agent bypasses every input scan unless you wire your own scanner.
-  Opt-in per-modality scanning (image OCR, PDF text extract, Whisper for
-  audio) is on the near-term roadmap; cost, latency, and data-egress
-  considerations mean it will ship as opt-in, not on-by-default.
+- **Multi-modal scanning is opt-in.** Image, PDF, and audio blocks pass
+  through without injection detection by default. Register a per-modality
+  extractor with `registerModalityScanner()` and call `scanMultiModal()`
+  from `governance-sdk/scan/multi-modal` before `enforce()`; the result's
+  concatenated text feeds the existing cascade. The SDK ships the
+  orchestration only — the actual OCR / PDF parser / ASR is caller-
+  supplied so the zero-dep promise stands. Defaults to text-only;
+  per-block timeouts and fail-closed semantics (`onMissingScanner`,
+  `onExtractError`) are configurable.
 
 ## Packages
 

--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -91,13 +91,15 @@ is exactly what it does and does not do:
   Tool executions **inside** AWS action groups are opaque — the adapter
   cannot see them, let alone block them. Use `guardToolUse()` to enforce
   at the tool level manually, or push tool calls onto the host side.
-- **Multi-modal content is not scanned by default.** Image, PDF, and audio
-  blocks on Anthropic/Vercel AI/Genkit/LlamaIndex/Bedrock pass through
-  without injection detection in the current release — a vision-enabled
-  agent bypasses every input scan unless you wire your own scanner.
-  Opt-in per-modality scanning (image OCR, PDF text extract, Whisper for
-  audio) is on the near-term roadmap; cost, latency, and data-egress
-  considerations mean it will ship as opt-in, not on-by-default.
+- **Multi-modal scanning is opt-in.** Image, PDF, and audio blocks pass
+  through without injection detection by default. Register a per-modality
+  extractor with `registerModalityScanner()` and call `scanMultiModal()`
+  from `governance-sdk/scan/multi-modal` before `enforce()`; the result's
+  concatenated text feeds the existing cascade. The SDK ships the
+  orchestration only — the actual OCR / PDF parser / ASR is caller-
+  supplied so the zero-dep promise stands. Defaults to text-only;
+  per-block timeouts and fail-closed semantics (`onMissingScanner`,
+  `onExtractError`) are configurable.
 
 ## Packages
 

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -73,6 +73,10 @@
       "types": "./dist/scanner-plugins/types.d.ts",
       "import": "./dist/scanner-plugins/types.js"
     },
+    "./scan/multi-modal": {
+      "types": "./dist/scan/multi-modal.d.ts",
+      "import": "./dist/scan/multi-modal.js"
+    },
     "./policy-compose": {
       "types": "./dist/policy-compose.d.ts",
       "import": "./dist/policy-compose.js"

--- a/packages/governance/src/scan/multi-modal.test.ts
+++ b/packages/governance/src/scan/multi-modal.test.ts
@@ -1,0 +1,314 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  scanMultiModal,
+  registerModalityScanner,
+  unregisterModalityScanner,
+  clearModalityScanners,
+  hasModalityScanner,
+  getModalityScanner,
+  isFailClosed,
+  type ContentBlock,
+  type ModalityScanner,
+} from "./multi-modal.js";
+
+describe("scanMultiModal", () => {
+  beforeEach(() => clearModalityScanners());
+  afterEach(() => clearModalityScanners());
+
+  // ─── Defaults ─────────────────────────────────────────────────
+
+  test("default enabled is text-only — image/pdf/audio blocks are skipped", async () => {
+    const blocks: ContentBlock[] = [
+      { modality: "text", text: "hello" },
+      { modality: "image", data: { url: "https://x" } },
+      { modality: "pdf", data: { bytes: new Uint8Array() } },
+      { modality: "audio", data: { wav: new Uint8Array() } },
+    ];
+
+    const result = await scanMultiModal(blocks);
+
+    assert.equal(result.text, "hello");
+    assert.deepEqual(result.modalitiesScanned, ["text"]);
+    assert.equal(result.modalitiesSkipped.length, 3);
+    assert.equal(result.blocked.length, 0);
+    for (const skip of result.modalitiesSkipped) {
+      assert.equal(skip.reason, "not_enabled");
+    }
+  });
+
+  test("text-only payload joins with double-newline", async () => {
+    const result = await scanMultiModal([
+      { modality: "text", text: "first" },
+      { modality: "text", text: "second" },
+    ]);
+    assert.equal(result.text, "first\n\nsecond");
+    assert.deepEqual(result.modalitiesScanned, ["text"]);
+  });
+
+  test("empty text blocks are dropped", async () => {
+    const result = await scanMultiModal([
+      { modality: "text", text: "" },
+      { modality: "text", text: "real content" },
+    ]);
+    assert.equal(result.text, "real content");
+  });
+
+  // ─── Opt-in ───────────────────────────────────────────────────
+
+  test("registered image scanner runs when image modality is enabled", async () => {
+    registerModalityScanner("image", {
+      extractText: async (block) =>
+        `OCR(${(block as { url: string }).url})`,
+    });
+
+    const result = await scanMultiModal(
+      [
+        { modality: "text", text: "user prompt" },
+        { modality: "image", data: { url: "image-1.png" } },
+      ],
+      { enabled: ["text", "image"] },
+    );
+
+    assert.equal(result.text, "user prompt\n\nOCR(image-1.png)");
+    assert.deepEqual(
+      result.modalitiesScanned.sort(),
+      ["image", "text"],
+    );
+    assert.equal(result.blocked.length, 0);
+  });
+
+  test("Set-based enabled is equivalent to array-based", async () => {
+    registerModalityScanner("pdf", {
+      extractText: async () => "pdf-text",
+    });
+
+    const arrayResult = await scanMultiModal(
+      [{ modality: "pdf", data: {} }],
+      { enabled: ["pdf"] },
+    );
+    const setResult = await scanMultiModal(
+      [{ modality: "pdf", data: {} }],
+      { enabled: new Set(["pdf"]) },
+    );
+
+    assert.equal(arrayResult.text, setResult.text);
+    assert.equal(arrayResult.text, "pdf-text");
+  });
+
+  // ─── Failure modes ────────────────────────────────────────────
+
+  test("enabled modality with no scanner ends up in blocked[]", async () => {
+    const result = await scanMultiModal(
+      [{ modality: "image", data: {} }],
+      { enabled: ["text", "image"] },
+    );
+
+    assert.equal(result.modalitiesScanned.length, 0);
+    assert.equal(result.blocked.length, 1);
+    assert.equal(result.blocked[0].modality, "image");
+    assert.equal(result.blocked[0].reason, "no_scanner");
+  });
+
+  test("scanner that throws ends up in blocked[] with extract_error", async () => {
+    registerModalityScanner("image", {
+      extractText: async () => {
+        throw new Error("boom");
+      },
+    });
+
+    const result = await scanMultiModal(
+      [{ modality: "image", data: {} }],
+      { enabled: ["image"] },
+    );
+
+    assert.equal(result.blocked.length, 1);
+    assert.equal(result.blocked[0].reason, "extract_error");
+    assert.equal(result.blocked[0].detail, "boom");
+  });
+
+  test("scanner that synchronously throws ends up in blocked[] with extract_error", async () => {
+    registerModalityScanner("image", {
+      extractText: ((() => {
+        throw new Error("sync boom");
+      }) as unknown) as ModalityScanner["extractText"],
+    });
+
+    const result = await scanMultiModal(
+      [{ modality: "image", data: {} }],
+      { enabled: ["image"] },
+    );
+
+    assert.equal(result.blocked.length, 1);
+    assert.equal(result.blocked[0].reason, "extract_error");
+    assert.equal(result.blocked[0].detail, "sync boom");
+  });
+
+  test("scanner that returns null ends up in blocked[] with extract_empty", async () => {
+    registerModalityScanner("image", {
+      extractText: async () => null,
+    });
+
+    const result = await scanMultiModal(
+      [{ modality: "image", data: {} }],
+      { enabled: ["image"] },
+    );
+
+    assert.equal(result.blocked.length, 1);
+    assert.equal(result.blocked[0].reason, "extract_empty");
+  });
+
+  test("scanner returning non-string ends up in blocked[] with extract_error", async () => {
+    registerModalityScanner("image", {
+      // Force a non-string return value through the type system to test
+      // runtime defence against badly-implemented scanners.
+      extractText: (async () => 42) as unknown as ModalityScanner["extractText"],
+    });
+
+    const result = await scanMultiModal(
+      [{ modality: "image", data: {} }],
+      { enabled: ["image"] },
+    );
+
+    assert.equal(result.blocked.length, 1);
+    assert.equal(result.blocked[0].reason, "extract_error");
+    assert.match(result.blocked[0].detail ?? "", /non-string/);
+  });
+
+  test("scanner that hangs is reaped by timeoutMs", async () => {
+    registerModalityScanner("image", {
+      extractText: () =>
+        new Promise<string>(() => {
+          // never resolves
+        }),
+    });
+
+    const result = await scanMultiModal(
+      [{ modality: "image", data: {} }],
+      { enabled: ["image"], timeoutMs: 50 },
+    );
+
+    assert.equal(result.blocked.length, 1);
+    assert.equal(result.blocked[0].reason, "extract_timeout");
+  });
+
+  // ─── isFailClosed ─────────────────────────────────────────────
+
+  test("isFailClosed is false on a clean result", () => {
+    const ok = isFailClosed({
+      text: "x",
+      modalitiesScanned: ["text"],
+      modalitiesSkipped: [],
+      blocked: [],
+      durationMs: 0,
+    });
+    assert.equal(ok, false);
+  });
+
+  test("isFailClosed honors onMissingScanner=block", () => {
+    const result = {
+      text: "",
+      modalitiesScanned: [],
+      modalitiesSkipped: [],
+      blocked: [{ modality: "image" as const, reason: "no_scanner" as const }],
+      durationMs: 0,
+    };
+    assert.equal(isFailClosed(result, { onMissingScanner: "skip" }), false);
+    assert.equal(isFailClosed(result, { onMissingScanner: "block" }), true);
+  });
+
+  test("isFailClosed honors onExtractError=block for non-no_scanner reasons", () => {
+    const errorResult = {
+      text: "",
+      modalitiesScanned: [],
+      modalitiesSkipped: [],
+      blocked: [
+        { modality: "pdf" as const, reason: "extract_error" as const },
+      ],
+      durationMs: 0,
+    };
+    const timeoutResult = {
+      text: "",
+      modalitiesScanned: [],
+      modalitiesSkipped: [],
+      blocked: [
+        { modality: "audio" as const, reason: "extract_timeout" as const },
+      ],
+      durationMs: 0,
+    };
+    assert.equal(isFailClosed(errorResult, { onExtractError: "skip" }), false);
+    assert.equal(isFailClosed(errorResult, { onExtractError: "block" }), true);
+    assert.equal(isFailClosed(timeoutResult, { onExtractError: "block" }), true);
+  });
+
+  test("isFailClosed: error and missing reasons are gated independently", () => {
+    const mixed = {
+      text: "",
+      modalitiesScanned: [],
+      modalitiesSkipped: [],
+      blocked: [
+        { modality: "image" as const, reason: "no_scanner" as const },
+        { modality: "pdf" as const, reason: "extract_error" as const },
+      ],
+      durationMs: 0,
+    };
+    // Only error gated → still fail-closed (the pdf row triggers it)
+    assert.equal(
+      isFailClosed(mixed, { onMissingScanner: "skip", onExtractError: "block" }),
+      true,
+    );
+    // Only missing gated → still fail-closed (the image row triggers it)
+    assert.equal(
+      isFailClosed(mixed, { onMissingScanner: "block", onExtractError: "skip" }),
+      true,
+    );
+  });
+});
+
+describe("modality scanner registry", () => {
+  beforeEach(() => clearModalityScanners());
+
+  test("hasModalityScanner reflects registration", () => {
+    assert.equal(hasModalityScanner("image"), false);
+    registerModalityScanner("image", { extractText: async () => "ok" });
+    assert.equal(hasModalityScanner("image"), true);
+  });
+
+  test("getModalityScanner returns the registered instance", () => {
+    const scanner: ModalityScanner = { extractText: async () => "ok" };
+    registerModalityScanner("pdf", scanner);
+    assert.equal(getModalityScanner("pdf"), scanner);
+    assert.equal(getModalityScanner("image"), null);
+  });
+
+  test("unregisterModalityScanner removes a single registration", () => {
+    registerModalityScanner("image", { extractText: async () => "i" });
+    registerModalityScanner("pdf", { extractText: async () => "p" });
+
+    unregisterModalityScanner("image");
+
+    assert.equal(hasModalityScanner("image"), false);
+    assert.equal(hasModalityScanner("pdf"), true);
+  });
+
+  test("registering twice replaces the prior scanner", async () => {
+    registerModalityScanner("image", { extractText: async () => "first" });
+    registerModalityScanner("image", { extractText: async () => "second" });
+
+    const result = await scanMultiModal(
+      [{ modality: "image", data: {} }],
+      { enabled: ["image"] },
+    );
+    assert.equal(result.text, "second");
+  });
+
+  test("clearModalityScanners empties the registry", () => {
+    registerModalityScanner("image", { extractText: async () => "ok" });
+    registerModalityScanner("pdf", { extractText: async () => "ok" });
+
+    clearModalityScanners();
+
+    assert.equal(hasModalityScanner("image"), false);
+    assert.equal(hasModalityScanner("pdf"), false);
+  });
+});

--- a/packages/governance/src/scan/multi-modal.test.ts
+++ b/packages/governance/src/scan/multi-modal.test.ts
@@ -31,7 +31,9 @@ describe("scanMultiModal", () => {
     assert.equal(result.text, "hello");
     assert.deepEqual(result.modalitiesScanned, ["text"]);
     assert.equal(result.modalitiesSkipped.length, 3);
+    assert.equal(result.modalitiesEmpty.length, 0);
     assert.equal(result.blocked.length, 0);
+    assert.equal(result.failClosed, false);
     for (const skip of result.modalitiesSkipped) {
       assert.equal(skip.reason, "not_enabled");
     }
@@ -52,6 +54,13 @@ describe("scanMultiModal", () => {
       { modality: "text", text: "real content" },
     ]);
     assert.equal(result.text, "real content");
+  });
+
+  test("policy defaults to skip/skip when options omitted", async () => {
+    const result = await scanMultiModal([{ modality: "text", text: "x" }]);
+    assert.equal(result.policy.onMissingScanner, "skip");
+    assert.equal(result.policy.onExtractError, "skip");
+    assert.equal(result.failClosed, false);
   });
 
   // ─── Opt-in ───────────────────────────────────────────────────
@@ -76,6 +85,7 @@ describe("scanMultiModal", () => {
       ["image", "text"],
     );
     assert.equal(result.blocked.length, 0);
+    assert.equal(result.failClosed, false);
   });
 
   test("Set-based enabled is equivalent to array-based", async () => {
@@ -94,6 +104,55 @@ describe("scanMultiModal", () => {
 
     assert.equal(arrayResult.text, setResult.text);
     assert.equal(arrayResult.text, "pdf-text");
+  });
+
+  // ─── Pre-evaluated failClosed (regression: bug-bot HIGH severity) ────
+
+  test("scanMultiModal HONOURS onMissingScanner='block' — failClosed=true on result", async () => {
+    // Regression test for the high-severity bug where ScanOptions
+    // accepted onMissingScanner/onExtractError but never read them.
+    const result = await scanMultiModal(
+      [{ modality: "image", data: {} }],
+      { enabled: ["image"], onMissingScanner: "block" },
+    );
+
+    assert.equal(result.blocked.length, 1);
+    assert.equal(result.blocked[0].reason, "no_scanner");
+    assert.equal(
+      result.failClosed,
+      true,
+      "failClosed must reflect onMissingScanner='block' that was passed in",
+    );
+    assert.equal(result.policy.onMissingScanner, "block");
+  });
+
+  test("scanMultiModal HONOURS onExtractError='block' — failClosed=true on scanner throw", async () => {
+    registerModalityScanner("image", {
+      extractText: async () => {
+        throw new Error("boom");
+      },
+    });
+
+    const result = await scanMultiModal(
+      [{ modality: "image", data: {} }],
+      { enabled: ["image"], onExtractError: "block" },
+    );
+
+    assert.equal(result.blocked.length, 1);
+    assert.equal(result.blocked[0].reason, "extract_error");
+    assert.equal(result.failClosed, true);
+    assert.equal(result.policy.onExtractError, "block");
+  });
+
+  test("onMissingScanner='skip' (default) does NOT trigger failClosed", async () => {
+    const result = await scanMultiModal(
+      [{ modality: "image", data: {} }],
+      { enabled: ["image"] },
+    );
+
+    assert.equal(result.blocked.length, 1);
+    assert.equal(result.blocked[0].reason, "no_scanner");
+    assert.equal(result.failClosed, false);
   });
 
   // ─── Failure modes ────────────────────────────────────────────
@@ -144,24 +203,8 @@ describe("scanMultiModal", () => {
     assert.equal(result.blocked[0].detail, "sync boom");
   });
 
-  test("scanner that returns null ends up in blocked[] with extract_empty", async () => {
-    registerModalityScanner("image", {
-      extractText: async () => null,
-    });
-
-    const result = await scanMultiModal(
-      [{ modality: "image", data: {} }],
-      { enabled: ["image"] },
-    );
-
-    assert.equal(result.blocked.length, 1);
-    assert.equal(result.blocked[0].reason, "extract_empty");
-  });
-
   test("scanner returning non-string ends up in blocked[] with extract_error", async () => {
     registerModalityScanner("image", {
-      // Force a non-string return value through the type system to test
-      // runtime defence against badly-implemented scanners.
       extractText: (async () => 42) as unknown as ModalityScanner["extractText"],
     });
 
@@ -192,64 +235,125 @@ describe("scanMultiModal", () => {
     assert.equal(result.blocked[0].reason, "extract_timeout");
   });
 
-  // ─── isFailClosed ─────────────────────────────────────────────
+  // ─── extract_empty semantics (regression: bug-bot MEDIUM severity) ───
 
-  test("isFailClosed is false on a clean result", () => {
-    const ok = isFailClosed({
-      text: "x",
-      modalitiesScanned: ["text"],
-      modalitiesSkipped: [],
-      blocked: [],
-      durationMs: 0,
+  test("scanner returning null is recorded in modalitiesEmpty, NOT blocked[]", async () => {
+    // Regression test for the medium-severity bug where null returns
+    // were misclassified as failures and subject to fail-closed.
+    registerModalityScanner("image", {
+      extractText: async () => null,
     });
-    assert.equal(ok, false);
+
+    const result = await scanMultiModal(
+      [{ modality: "image", data: {} }],
+      { enabled: ["image"] },
+    );
+
+    assert.equal(result.blocked.length, 0, "null returns must not appear in blocked[]");
+    assert.equal(result.modalitiesEmpty.length, 1);
+    assert.equal(result.modalitiesEmpty[0].modality, "image");
+    assert.deepEqual(result.modalitiesScanned, ["image"]);
+    assert.equal(result.failClosed, false);
   });
 
-  test("isFailClosed honors onMissingScanner=block", () => {
+  test("scanner returning null does NOT trigger failClosed even with onExtractError='block'", async () => {
+    // The documented contract: returning null is "no extractable text"
+    // (e.g. a purely visual image), not an error. onExtractError must
+    // not gate this benign signal.
+    registerModalityScanner("image", {
+      extractText: async () => null,
+    });
+
+    const result = await scanMultiModal(
+      [{ modality: "image", data: {} }],
+      { enabled: ["image"], onExtractError: "block" },
+    );
+
+    assert.equal(result.failClosed, false, "null returns are benign — must not fail-closed");
+    assert.equal(result.modalitiesEmpty.length, 1);
+  });
+
+  test("undefined return treated identically to null", async () => {
+    registerModalityScanner("image", {
+      extractText: (async () => undefined) as unknown as ModalityScanner["extractText"],
+    });
+
+    const result = await scanMultiModal(
+      [{ modality: "image", data: {} }],
+      { enabled: ["image"], onExtractError: "block" },
+    );
+
+    assert.equal(result.blocked.length, 0);
+    assert.equal(result.modalitiesEmpty.length, 1);
+    assert.equal(result.failClosed, false);
+  });
+
+  // ─── isFailClosed (override helper) ────────────────────────────
+
+  test("isFailClosed defaults to result.policy when no override given", () => {
     const result = {
       text: "",
       modalitiesScanned: [],
       modalitiesSkipped: [],
+      modalitiesEmpty: [],
       blocked: [{ modality: "image" as const, reason: "no_scanner" as const }],
+      failClosed: true,
+      policy: { onMissingScanner: "block" as const, onExtractError: "skip" as const },
       durationMs: 0,
     };
-    assert.equal(isFailClosed(result, { onMissingScanner: "skip" }), false);
-    assert.equal(isFailClosed(result, { onMissingScanner: "block" }), true);
+    assert.equal(isFailClosed(result), true);
   });
 
-  test("isFailClosed honors onExtractError=block for non-no_scanner reasons", () => {
-    const errorResult = {
+  test("isFailClosed override loosens result.policy", () => {
+    const result = {
       text: "",
       modalitiesScanned: [],
       modalitiesSkipped: [],
+      modalitiesEmpty: [],
+      blocked: [{ modality: "image" as const, reason: "no_scanner" as const }],
+      failClosed: true,
+      policy: { onMissingScanner: "block" as const, onExtractError: "skip" as const },
+      durationMs: 0,
+    };
+    assert.equal(
+      isFailClosed(result, { onMissingScanner: "skip" }),
+      false,
+      "override skip must override stored block policy",
+    );
+  });
+
+  test("isFailClosed override tightens result.policy", () => {
+    const result = {
+      text: "",
+      modalitiesScanned: [],
+      modalitiesSkipped: [],
+      modalitiesEmpty: [],
       blocked: [
         { modality: "pdf" as const, reason: "extract_error" as const },
       ],
+      failClosed: false,
+      policy: { onMissingScanner: "skip" as const, onExtractError: "skip" as const },
       durationMs: 0,
     };
-    const timeoutResult = {
-      text: "",
-      modalitiesScanned: [],
-      modalitiesSkipped: [],
-      blocked: [
-        { modality: "audio" as const, reason: "extract_timeout" as const },
-      ],
-      durationMs: 0,
-    };
-    assert.equal(isFailClosed(errorResult, { onExtractError: "skip" }), false);
-    assert.equal(isFailClosed(errorResult, { onExtractError: "block" }), true);
-    assert.equal(isFailClosed(timeoutResult, { onExtractError: "block" }), true);
+    assert.equal(
+      isFailClosed(result, { onExtractError: "block" }),
+      true,
+      "override block must apply to a previously-permissive scan",
+    );
   });
 
-  test("isFailClosed: error and missing reasons are gated independently", () => {
+  test("isFailClosed: error and missing reasons gated independently", () => {
     const mixed = {
       text: "",
       modalitiesScanned: [],
       modalitiesSkipped: [],
+      modalitiesEmpty: [],
       blocked: [
         { modality: "image" as const, reason: "no_scanner" as const },
         { modality: "pdf" as const, reason: "extract_error" as const },
       ],
+      failClosed: false,
+      policy: { onMissingScanner: "skip" as const, onExtractError: "skip" as const },
       durationMs: 0,
     };
     // Only error gated → still fail-closed (the pdf row triggers it)
@@ -262,6 +366,23 @@ describe("scanMultiModal", () => {
       isFailClosed(mixed, { onMissingScanner: "block", onExtractError: "skip" }),
       true,
     );
+  });
+
+  test("isFailClosed: extract_timeout is gated by onExtractError", () => {
+    const result = {
+      text: "",
+      modalitiesScanned: [],
+      modalitiesSkipped: [],
+      modalitiesEmpty: [],
+      blocked: [
+        { modality: "audio" as const, reason: "extract_timeout" as const },
+      ],
+      failClosed: false,
+      policy: { onMissingScanner: "skip" as const, onExtractError: "skip" as const },
+      durationMs: 0,
+    };
+    assert.equal(isFailClosed(result, { onExtractError: "skip" }), false);
+    assert.equal(isFailClosed(result, { onExtractError: "block" }), true);
   });
 });
 

--- a/packages/governance/src/scan/multi-modal.ts
+++ b/packages/governance/src/scan/multi-modal.ts
@@ -1,0 +1,331 @@
+/**
+ * governance-sdk — Multi-Modal Scan Orchestration
+ *
+ * The SDK's injection cascade scans text. Image, PDF, and audio content
+ * blocks pass through it untouched unless something extracts text first.
+ * This file ships the orchestration; the actual extractors (OCR, PDF
+ * parsing, ASR) are caller-supplied via `registerModalityScanner` so
+ * the SDK stays zero-runtime-dep.
+ *
+ * **Opt-in by default.** Every modality except `text` is OFF unless the
+ * caller enables it explicitly. Reasons:
+ *   - Cost: OCR / Whisper inference per request is non-trivial.
+ *   - Latency: extraction adds 100ms–10s depending on payload + tool.
+ *   - Privacy: some customers cannot have payload content read by
+ *     anything other than the model itself.
+ *
+ * **Wiring with the existing cascade:**
+ *   1. Caller registers extractors at startup:
+ *      `registerModalityScanner('image', { extractText: ... })`
+ *   2. Per request, caller invokes `scanMultiModal(blocks, { enabled: ['text','image'] })`
+ *      BEFORE `gov.enforce()`.
+ *   3. The returned `text` is the concatenation of all scanned blocks. Run
+ *      it through `detectInjection()` / `hybridDetect()` and populate
+ *      `ctx.mlInjectionScore` as usual.
+ *   4. If `result.blocked.length > 0`, treat as fail-closed (set the score
+ *      to 1.0 or block out-of-band). The SDK does not auto-block — it
+ *      surfaces the failure so policy can decide.
+ *
+ * Mirrors the InjectionClassifier pattern in `injection-classifier.ts` —
+ * same async hook + global registry + pre-`enforce()` invocation shape.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────
+
+/** Recognised content modalities. */
+export type Modality = "text" | "image" | "pdf" | "audio";
+
+/**
+ * Pluggable scanner that converts a non-text block into text the
+ * cascade can scan. Implementations are caller-supplied so the SDK has
+ * zero runtime deps on Tesseract / pdf-parse / Whisper / vision LLMs.
+ */
+export interface ModalityScanner {
+  /**
+   * Extract scannable text from `block`. Return `null` if the block has
+   * no extractable text (e.g. an image that's purely visual). Throw or
+   * reject to signal a failure that the orchestrator should classify as
+   * an unscannable block.
+   */
+  extractText(block: unknown): Promise<string | null>;
+}
+
+/**
+ * One block of content in a possibly-multi-modal payload. The orchestrator
+ * uses `modality` to pick the registered scanner; `text` is consumed
+ * directly when `modality === 'text'`; `data` is opaque and forwarded to
+ * the scanner for everything else.
+ */
+export interface ContentBlock {
+  modality: Modality;
+  /** Used directly when `modality === 'text'`. Ignored otherwise. */
+  text?: string;
+  /** Forwarded to the registered scanner for non-text modalities. */
+  data?: unknown;
+}
+
+/**
+ * What the orchestrator did and didn't manage to scan. Callers should
+ * fail-closed if `blocked.length > 0`.
+ */
+export interface MultiModalScanResult {
+  /** Concatenation of all extracted text, separated by `\n\n`. */
+  text: string;
+  /** Modalities for which at least one block was scanned successfully. */
+  modalitiesScanned: Modality[];
+  /**
+   * Blocks that were intentionally not scanned because their modality
+   * was not in the enabled set. Not a failure — informational.
+   */
+  modalitiesSkipped: { modality: Modality; reason: "not_enabled" }[];
+  /**
+   * Blocks the orchestrator could not scan: enabled-but-no-scanner,
+   * scanner threw, scanner timed out, or scanner returned null. Treat
+   * as fail-closed when `onMissingScanner` or `onExtractError` is `'block'`.
+   */
+  blocked: {
+    modality: Modality;
+    reason: "no_scanner" | "extract_error" | "extract_timeout" | "extract_empty";
+    detail?: string;
+  }[];
+  /** Wall-clock time spent in scanners + orchestration. */
+  durationMs: number;
+}
+
+/** Options controlling modality opt-in and failure-mode policy. */
+export interface ScanOptions {
+  /**
+   * Modalities to scan this call. Default: `['text']`. Opt in to anything
+   * else explicitly. Accepts an array or a Set.
+   */
+  enabled?: readonly Modality[] | ReadonlySet<Modality>;
+  /**
+   * What to do when an enabled modality has no registered scanner:
+   *   - `'skip'` (default): drop the block, record in `blocked[]` with
+   *     reason `no_scanner`.
+   *   - `'block'`: same plus the caller should treat the result as fail-closed.
+   *
+   * Both modes record the block; the difference is callers' interpretation.
+   * The orchestrator never throws — it surfaces the situation so policy
+   * can decide.
+   */
+  onMissingScanner?: "skip" | "block";
+  /**
+   * What to do when a scanner throws or rejects. Same shape as
+   * `onMissingScanner`. Default: `'skip'`.
+   */
+  onExtractError?: "skip" | "block";
+  /**
+   * Per-block extraction timeout in ms. Default 30_000. Timeouts count
+   * as `extract_timeout` in `blocked[]`.
+   */
+  timeoutMs?: number;
+}
+
+// ─── Registry ────────────────────────────────────────────────────
+
+const scanners = new Map<Modality, ModalityScanner>();
+
+/**
+ * Register an extractor for a modality. Replaces any existing scanner
+ * for that modality. Call once at startup (or per-tenant if you need
+ * per-tenant extractors — wrap the call yourself).
+ */
+export function registerModalityScanner(
+  modality: Modality,
+  scanner: ModalityScanner,
+): void {
+  scanners.set(modality, scanner);
+}
+
+/** Look up the registered scanner for a modality (or null). */
+export function getModalityScanner(modality: Modality): ModalityScanner | null {
+  return scanners.get(modality) ?? null;
+}
+
+/** Remove a single scanner registration. No-op if none registered. */
+export function unregisterModalityScanner(modality: Modality): void {
+  scanners.delete(modality);
+}
+
+/** Wipe all registrations. Mainly for tests. */
+export function clearModalityScanners(): void {
+  scanners.clear();
+}
+
+/** True if any non-text scanner is registered. */
+export function hasModalityScanner(modality: Modality): boolean {
+  return scanners.has(modality);
+}
+
+// ─── Orchestrator ────────────────────────────────────────────────
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_ENABLED: readonly Modality[] = ["text"];
+
+function toEnabledSet(
+  enabled: ScanOptions["enabled"] | undefined,
+): ReadonlySet<Modality> {
+  if (!enabled) return new Set(DEFAULT_ENABLED);
+  if (enabled instanceof Set) return enabled;
+  return new Set(enabled);
+}
+
+type RaceResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; reason: "timeout" }
+  | { ok: false; reason: "error"; detail: string };
+
+/**
+ * Race a promise against a timeout. Catches both rejections and timeouts
+ * so the caller never sees an unhandled rejection from a scanner.
+ */
+async function withTimeout<T>(p: Promise<T>, ms: number): Promise<RaceResult<T>> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<RaceResult<T>>((resolve) => {
+    timer = setTimeout(
+      () => resolve({ ok: false, reason: "timeout" }),
+      ms,
+    );
+  });
+  const wrapped: Promise<RaceResult<T>> = p.then(
+    (value) => ({ ok: true, value }),
+    (err: unknown) => ({
+      ok: false,
+      reason: "error",
+      detail: err instanceof Error ? err.message : String(err),
+    }),
+  );
+  try {
+    return await Promise.race([wrapped, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Walk `blocks` and produce a single concatenated text payload along with
+ * structured per-block scan results. Returns even when individual blocks
+ * fail — `blocked[]` is the source of truth for fail-closed decisions.
+ */
+export async function scanMultiModal(
+  blocks: readonly ContentBlock[],
+  options: ScanOptions = {},
+): Promise<MultiModalScanResult> {
+  const startedAt = Date.now();
+  const enabled = toEnabledSet(options.enabled);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const extractedTexts: string[] = [];
+  const scannedSet = new Set<Modality>();
+  const skipped: MultiModalScanResult["modalitiesSkipped"] = [];
+  const blocked: MultiModalScanResult["blocked"] = [];
+
+  for (const block of blocks) {
+    const { modality } = block;
+
+    if (!enabled.has(modality)) {
+      skipped.push({ modality, reason: "not_enabled" });
+      continue;
+    }
+
+    if (modality === "text") {
+      if (typeof block.text === "string" && block.text.length > 0) {
+        extractedTexts.push(block.text);
+        scannedSet.add("text");
+      }
+      continue;
+    }
+
+    const scanner = scanners.get(modality);
+    if (!scanner) {
+      blocked.push({
+        modality,
+        reason: "no_scanner",
+        detail: `No scanner registered for modality '${modality}'`,
+      });
+      continue;
+    }
+
+    let extractPromise: Promise<string | null>;
+    try {
+      extractPromise = scanner.extractText(block.data);
+    } catch (err) {
+      // Synchronous throw from the scanner. Treat as extract_error.
+      blocked.push({
+        modality,
+        reason: "extract_error",
+        detail: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+
+    const raced = await withTimeout(extractPromise, timeoutMs);
+
+    if (!raced.ok) {
+      if (raced.reason === "timeout") {
+        blocked.push({
+          modality,
+          reason: "extract_timeout",
+          detail: `Scanner exceeded ${timeoutMs}ms`,
+        });
+      } else {
+        blocked.push({
+          modality,
+          reason: "extract_error",
+          detail: raced.detail,
+        });
+      }
+      continue;
+    }
+
+    const value = raced.value;
+    if (value === null || value === undefined) {
+      blocked.push({
+        modality,
+        reason: "extract_empty",
+        detail: "Scanner returned no text",
+      });
+      continue;
+    }
+
+    if (typeof value !== "string") {
+      blocked.push({
+        modality,
+        reason: "extract_error",
+        detail: `Scanner returned non-string value: ${typeof value}`,
+      });
+      continue;
+    }
+
+    if (value.length > 0) extractedTexts.push(value);
+    scannedSet.add(modality);
+  }
+
+  return {
+    text: extractedTexts.join("\n\n"),
+    modalitiesScanned: Array.from(scannedSet),
+    modalitiesSkipped: skipped,
+    blocked,
+    durationMs: Date.now() - startedAt,
+  };
+}
+
+/**
+ * True if the scan result requires fail-closed treatment given the policy
+ * options. Mirrors the orchestrator's classification: `blocked[]` rows are
+ * fatal when the corresponding option is `'block'`.
+ */
+export function isFailClosed(
+  result: MultiModalScanResult,
+  options: Pick<ScanOptions, "onMissingScanner" | "onExtractError"> = {},
+): boolean {
+  const onMissing = options.onMissingScanner ?? "skip";
+  const onError = options.onExtractError ?? "skip";
+
+  for (const b of result.blocked) {
+    if (b.reason === "no_scanner" && onMissing === "block") return true;
+    if (b.reason !== "no_scanner" && onError === "block") return true;
+  }
+  return false;
+}

--- a/packages/governance/src/scan/multi-modal.ts
+++ b/packages/governance/src/scan/multi-modal.ts
@@ -22,9 +22,11 @@
  *   3. The returned `text` is the concatenation of all scanned blocks. Run
  *      it through `detectInjection()` / `hybridDetect()` and populate
  *      `ctx.mlInjectionScore` as usual.
- *   4. If `result.blocked.length > 0`, treat as fail-closed (set the score
- *      to 1.0 or block out-of-band). The SDK does not auto-block — it
- *      surfaces the failure so policy can decide.
+ *   4. If `result.failClosed` is true, fail closed — set the score to
+ *      1.0 or block out-of-band. The flag is pre-evaluated against the
+ *      `onMissingScanner` / `onExtractError` options you passed to
+ *      `scanMultiModal`. Use `isFailClosed(result, override)` only if
+ *      you want to apply a different policy after the fact.
  *
  * Mirrors the InjectionClassifier pattern in `injection-classifier.ts` —
  * same async hook + global registry + pre-`enforce()` invocation shape.
@@ -43,9 +45,10 @@ export type Modality = "text" | "image" | "pdf" | "audio";
 export interface ModalityScanner {
   /**
    * Extract scannable text from `block`. Return `null` if the block has
-   * no extractable text (e.g. an image that's purely visual). Throw or
-   * reject to signal a failure that the orchestrator should classify as
-   * an unscannable block.
+   * no extractable text (e.g. an image that's purely visual). This is
+   * a successful, valid outcome and never triggers fail-closed. Throw
+   * or reject to signal a failure that the orchestrator should classify
+   * as an unscannable block.
    */
   extractText(block: unknown): Promise<string | null>;
 }
@@ -64,14 +67,30 @@ export interface ContentBlock {
   data?: unknown;
 }
 
+/** Scan failures that may warrant fail-closed treatment depending on policy. */
+export type ScanBlockReason = "no_scanner" | "extract_error" | "extract_timeout";
+
+/** Active policy controlling fail-closed evaluation. */
+export interface FailClosedPolicy {
+  onMissingScanner: "skip" | "block";
+  onExtractError: "skip" | "block";
+}
+
 /**
- * What the orchestrator did and didn't manage to scan. Callers should
- * fail-closed if `blocked.length > 0`.
+ * What the orchestrator did and didn't manage to scan. `failClosed` is
+ * pre-evaluated using the options that were passed to `scanMultiModal` —
+ * trust it directly. `isFailClosed(result, override)` is available if
+ * you need to reapply a different policy after the fact.
  */
 export interface MultiModalScanResult {
   /** Concatenation of all extracted text, separated by `\n\n`. */
   text: string;
-  /** Modalities for which at least one block was scanned successfully. */
+  /**
+   * Modalities for which at least one block was scanned successfully —
+   * including blocks that legitimately produced no text (`null` return
+   * for a purely visual image, etc.). The scan succeeded; text
+   * contribution may be empty.
+   */
   modalitiesScanned: Modality[];
   /**
    * Blocks that were intentionally not scanned because their modality
@@ -79,15 +98,30 @@ export interface MultiModalScanResult {
    */
   modalitiesSkipped: { modality: Modality; reason: "not_enabled" }[];
   /**
-   * Blocks the orchestrator could not scan: enabled-but-no-scanner,
-   * scanner threw, scanner timed out, or scanner returned null. Treat
-   * as fail-closed when `onMissingScanner` or `onExtractError` is `'block'`.
+   * Blocks where the scanner ran successfully but returned `null` /
+   * `undefined`, meaning the block has no extractable text (per the
+   * `ModalityScanner` contract — e.g. a purely visual image). Never a
+   * failure; never triggers fail-closed.
+   */
+  modalitiesEmpty: { modality: Modality }[];
+  /**
+   * Scan failures the orchestrator could not recover from:
+   * `no_scanner` (enabled but no extractor registered), `extract_error`
+   * (scanner threw / rejected / returned a non-string value),
+   * `extract_timeout` (scanner exceeded `timeoutMs`).
    */
   blocked: {
     modality: Modality;
-    reason: "no_scanner" | "extract_error" | "extract_timeout" | "extract_empty";
+    reason: ScanBlockReason;
     detail?: string;
   }[];
+  /**
+   * Pre-evaluated against the policy that was active when this scan ran.
+   * `true` if any block in `blocked[]` was fatal under that policy.
+   */
+  failClosed: boolean;
+  /** The policy applied when computing `failClosed`. */
+  policy: FailClosedPolicy;
   /** Wall-clock time spent in scanners + orchestration. */
   durationMs: number;
 }
@@ -102,17 +136,17 @@ export interface ScanOptions {
   /**
    * What to do when an enabled modality has no registered scanner:
    *   - `'skip'` (default): drop the block, record in `blocked[]` with
-   *     reason `no_scanner`.
-   *   - `'block'`: same plus the caller should treat the result as fail-closed.
-   *
-   * Both modes record the block; the difference is callers' interpretation.
-   * The orchestrator never throws — it surfaces the situation so policy
-   * can decide.
+   *     reason `no_scanner`, do NOT fail-closed.
+   *   - `'block'`: same recording, plus `failClosed` becomes `true`.
    */
   onMissingScanner?: "skip" | "block";
   /**
-   * What to do when a scanner throws or rejects. Same shape as
-   * `onMissingScanner`. Default: `'skip'`.
+   * What to do when a scanner throws, rejects, returns a non-string, or
+   * times out. Same shape as `onMissingScanner`. Default: `'skip'`.
+   *
+   * Does NOT apply to scanners returning `null` — that's the documented
+   * "no extractable text" signal and is recorded in `modalitiesEmpty[]`,
+   * not `blocked[]`.
    */
   onExtractError?: "skip" | "block";
   /**
@@ -204,9 +238,31 @@ async function withTimeout<T>(p: Promise<T>, ms: number): Promise<RaceResult<T>>
 }
 
 /**
+ * Evaluate fail-closed against `blocked[]` rows under the given policy.
+ * `extract_empty` is intentionally absent — null returns are valid per
+ * the ModalityScanner contract and live in `modalitiesEmpty[]`, not here.
+ */
+function evaluateFailClosed(
+  blocked: readonly { reason: ScanBlockReason }[],
+  policy: FailClosedPolicy,
+): boolean {
+  for (const b of blocked) {
+    if (b.reason === "no_scanner" && policy.onMissingScanner === "block") return true;
+    if (
+      (b.reason === "extract_error" || b.reason === "extract_timeout") &&
+      policy.onExtractError === "block"
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Walk `blocks` and produce a single concatenated text payload along with
- * structured per-block scan results. Returns even when individual blocks
- * fail — `blocked[]` is the source of truth for fail-closed decisions.
+ * structured per-block scan results. `failClosed` is pre-evaluated against
+ * the `onMissingScanner` / `onExtractError` options passed in — callers
+ * can trust it directly.
  */
 export async function scanMultiModal(
   blocks: readonly ContentBlock[],
@@ -215,10 +271,15 @@ export async function scanMultiModal(
   const startedAt = Date.now();
   const enabled = toEnabledSet(options.enabled);
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const policy: FailClosedPolicy = {
+    onMissingScanner: options.onMissingScanner ?? "skip",
+    onExtractError: options.onExtractError ?? "skip",
+  };
 
   const extractedTexts: string[] = [];
   const scannedSet = new Set<Modality>();
   const skipped: MultiModalScanResult["modalitiesSkipped"] = [];
+  const empty: MultiModalScanResult["modalitiesEmpty"] = [];
   const blocked: MultiModalScanResult["blocked"] = [];
 
   for (const block of blocks) {
@@ -281,11 +342,11 @@ export async function scanMultiModal(
 
     const value = raced.value;
     if (value === null || value === undefined) {
-      blocked.push({
-        modality,
-        reason: "extract_empty",
-        detail: "Scanner returned no text",
-      });
+      // Documented benign signal: "this block has no extractable text."
+      // Not a failure — record in modalitiesEmpty, count as scanned, no
+      // fail-closed implications.
+      empty.push({ modality });
+      scannedSet.add(modality);
       continue;
     }
 
@@ -306,26 +367,30 @@ export async function scanMultiModal(
     text: extractedTexts.join("\n\n"),
     modalitiesScanned: Array.from(scannedSet),
     modalitiesSkipped: skipped,
+    modalitiesEmpty: empty,
     blocked,
+    failClosed: evaluateFailClosed(blocked, policy),
+    policy,
     durationMs: Date.now() - startedAt,
   };
 }
 
 /**
- * True if the scan result requires fail-closed treatment given the policy
- * options. Mirrors the orchestrator's classification: `blocked[]` rows are
- * fatal when the corresponding option is `'block'`.
+ * Re-evaluate fail-closed against a different policy than the one used
+ * during `scanMultiModal`. Most callers should just check
+ * `result.failClosed` directly; reach for this only when you need to
+ * apply a stricter or more lenient policy after the fact.
+ *
+ * `extract_empty` is never fail-closed regardless of options — null
+ * returns from a scanner are documented benign signals.
  */
 export function isFailClosed(
   result: MultiModalScanResult,
-  options: Pick<ScanOptions, "onMissingScanner" | "onExtractError"> = {},
+  override?: Partial<FailClosedPolicy>,
 ): boolean {
-  const onMissing = options.onMissingScanner ?? "skip";
-  const onError = options.onExtractError ?? "skip";
-
-  for (const b of result.blocked) {
-    if (b.reason === "no_scanner" && onMissing === "block") return true;
-    if (b.reason !== "no_scanner" && onError === "block") return true;
-  }
-  return false;
+  const policy: FailClosedPolicy = {
+    onMissingScanner: override?.onMissingScanner ?? result.policy.onMissingScanner,
+    onExtractError: override?.onExtractError ?? result.policy.onExtractError,
+  };
+  return evaluateFailClosed(result.blocked, policy);
 }


### PR DESCRIPTION
## Summary
- New export `governance-sdk/scan/multi-modal` with a pluggable extractor registry and the `scanMultiModal()` orchestrator. Closes the bypass where image / PDF / audio blocks pass through `enforce()` unscanned.
- Ships orchestration only — actual OCR / PDF parsers / ASR are caller-supplied, preserving the zero-runtime-dep promise.
- Mirrors the existing `InjectionClassifier` pattern: async scanner interface + global registry + pre-`enforce()` invocation.

## API surface
\`\`\`ts
import {
  registerModalityScanner,
  scanMultiModal,
  isFailClosed,
} from 'governance-sdk/scan/multi-modal';

registerModalityScanner('image', {
  extractText: async (block) => ocrEngine.recognize(block),
});

const scan = await scanMultiModal(blocks, {
  enabled: ['text', 'image'],
  onMissingScanner: 'block',
  onExtractError: 'block',
  timeoutMs: 5_000,
});

if (isFailClosed(scan)) { /* block before enforce() */ }
// otherwise feed scan.text into the existing detectInjection / hybridDetect
\`\`\`

## Defaults (deliberately conservative)
- `enabled: ['text']` — every other modality off until explicitly opted in
- `onMissingScanner: 'skip'`, `onExtractError: 'skip'`
- `timeoutMs: 30_000` per block

## Failure modes (all surface in `result.blocked[]`)
- `no_scanner` — enabled but no extractor registered
- `extract_error` — scanner threw (sync or async) or returned non-string
- `extract_timeout` — exceeded `timeoutMs`
- `extract_empty` — scanner returned `null` / `undefined`

## Tests
20 new tests in `src/scan/multi-modal.test.ts` covering: defaults, opt-in modes, sync-throw and async-rejection paths, timeouts via Promise.race + setTimeout cleanup, registry CRUD, `isFailClosed` with mixed reasons. Full suite **1,392 / 0**.

## Merge order note
Modifies the README "Limitations" multi-modal bullet. If the README honesty pass PR merges first, this branch will have a trivial conflict on that one bullet — both edits are mine, easy resolve. Either way works; suggest merging the docs PR first.

## Out of scope (follow-ups)
- Framework adapters (Anthropic / Vercel AI / Genkit / LlamaIndex / Bedrock) auto-calling `scanMultiModal` on detection of non-text blocks. Today the caller wires it in their host code.
- Optional reference packages (e.g. `governance-sdk-scan-tesseract`) shipping default extractors as separate peer-deps. Keeps the core SDK zero-dep.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 1,392 / 0
- [ ] Reviewer skims `src/scan/multi-modal.ts` for the timeout / sync-throw paths
- [ ] Reviewer confirms `package.json` exports field is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new security-adjacent scanning behavior and a new public export surface; incorrect host wiring or misunderstandings of `failClosed`/default opt-in semantics could lead to gaps or unintended blocking, though the change is additive and well-tested.
> 
> **Overview**
> Adds a new `governance-sdk/scan/multi-modal` export that orchestrates opt-in text extraction for `image`/`pdf`/`audio` content blocks via a global registry (`registerModalityScanner`, `unregisterModalityScanner`, `clearModalityScanners`) and returns concatenated text plus structured scan outcomes and a pre-evaluated `failClosed` flag (`isFailClosed` helper).
> 
> Introduces timeout handling and explicit failure classification (`no_scanner`, `extract_error`, `extract_timeout`) while treating `null`/`undefined` extractor returns as benign “no text” results, backed by a comprehensive new test suite. Updates both READMEs to document that multi-modal scanning is now available but remains opt-in with caller-supplied OCR/PDF/ASR to preserve zero runtime deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f89155f9fb2a27b0e119873317bce85ef0ee5999. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->