### PR TITLE
feat(audit): per-org tamper-evident audit chains (0.18.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,24 @@ const chain = await gov.integrityChain!.export();
 const { valid, brokenAt, breakDetail } = await verifyAuditIntegrity(chain, process.env.AUDIT_SECRET!);
 ```
 
+**Per-org (multi-tenant) chains.** Since 0.18, chains are scoped per
+`organizationId`: each org gets its own head, its own `1..N` sequence, and
+its own write lock, so one tenant's events never interleave with another's.
+Pass the org on the context (or via `metadata.organizationId`) and export /
+verify a single tenant's contiguous chain:
+
+```typescript
+await gov.enforce({ agentId, organizationId: 'org_acme', action: 'tool_call', tool: 'search' });
+
+const acme = await gov.integrityChain!.export({ organizationId: 'org_acme' });
+await verifyAuditIntegrity(acme, process.env.AUDIT_SECRET!); // contiguous, standalone-verifiable
+```
+
+Events without an `organizationId` share a single org-less chain, byte-for-byte
+compatible with chains written before 0.18 — no migration needed. The org is
+bound into each event's hash (when present), so an event can't be relabelled
+into another tenant's chain without breaking verification.
+
 **What gets chained (when `integrityAudit` is set):**
 
 | Event type | Written by | What it captures |

--- a/packages/governance/CHANGELOG.md
+++ b/packages/governance/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [0.18.0] - 2026-06-26 — Per-org (multi-tenant) audit chains
+
+The tamper-evident audit chain is now scoped **per organization**. Before
+this release a single `createGovernance({ integrityAudit })` instance kept
+one global hash chain, so every org's events were interleaved into the same
+chain and sequence space — you couldn't hand one tenant a clean, contiguous,
+independently-verifiable export, and one tenant's volume affected another's
+chain. Now each `organizationId` gets its own head, its own 1..N sequence,
+and its own write lock; events with no org share a single org-less chain,
+byte-for-byte compatible with chains written before this release.
+
+Additive and backward-compatible — org-less usage is unchanged.
+
+### Added
+
+- `EnforcementContext.organizationId`, `AgentRegistration.organizationId`,
+  `ActionOutcome.organizationId` — supply the tenant to scope its chain.
+  `enforce()` / `enforceStage()` also fall back to `metadata.organizationId`.
+- `integrityChain.stats(organizationId?)` and `integrityChain.export({ organizationId })`
+  now operate on a single org's chain.
+- `GovernanceStorage.getChainHead(organizationId?)` — resume the right org's
+  chain on restart. The in-memory and Postgres adapters implement it.
+
+### Changed
+
+- `canonicalize()` binds `organizationId` into the per-event hash **only when
+  present**, so an event cannot be relabelled into another org's chain without
+  detection. Org-less events hash exactly as before (no migration needed).
+- Postgres adapter now persists `organization_id` on agents and audit events
+  (the columns/indexes already existed but were never written), and the
+  `integrity_sequence` unique index is now per-org
+  (`(COALESCE(organization_id,''), integrity_sequence)`). The integrity
+  migration drops the old global unique index and creates the composite one
+  — idempotent, safe on existing rows.
+
 ## [0.17.0] - 2026-05-07 — Custom conditions reachable from `createGovernance()`
 
 The condition registry (`registerCondition` / `unregisterCondition` /

--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -399,6 +399,24 @@ const chain = await gov.integrityChain!.export();
 const { valid, brokenAt, breakDetail } = await verifyAuditIntegrity(chain, process.env.AUDIT_SECRET!);
 ```
 
+**Per-org (multi-tenant) chains.** Since 0.18, chains are scoped per
+`organizationId`: each org gets its own head, its own `1..N` sequence, and
+its own write lock, so one tenant's events never interleave with another's.
+Pass the org on the context (or via `metadata.organizationId`) and export /
+verify a single tenant's contiguous chain:
+
+```typescript
+await gov.enforce({ agentId, organizationId: 'org_acme', action: 'tool_call', tool: 'search' });
+
+const acme = await gov.integrityChain!.export({ organizationId: 'org_acme' });
+await verifyAuditIntegrity(acme, process.env.AUDIT_SECRET!); // contiguous, standalone-verifiable
+```
+
+Events without an `organizationId` share a single org-less chain, byte-for-byte
+compatible with chains written before 0.18 — no migration needed. The org is
+bound into each event's hash (when present), so an event can't be relabelled
+into another tenant's chain without breaking verification.
+
 **What gets chained (when `integrityAudit` is set):**
 
 | Event type | Written by | What it captures |

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "governance-sdk",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "AI Agent Governance for TypeScript — policy enforcement, scoring, compliance, and audit for AI agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/governance/src/audit-chain-per-org.test.ts
+++ b/packages/governance/src/audit-chain-per-org.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Per-org integrity audit chain tests.
+ *
+ * Chains are scoped per organization: each org gets an independent HMAC chain
+ * with its own head and its own 1..N sequence. This means:
+ *   - one org's events never interleave into another org's chain
+ *   - a single org's exported slice is contiguous and verifies standalone
+ *   - relabelling an event into a different org breaks its hash (org is bound
+ *     into the canonical form)
+ *   - events with NO organizationId share one org-less chain, byte-for-byte
+ *     compatible with chains written before per-org scoping existed
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createGovernance } from "./index";
+import { verifyAuditIntegrity } from "./audit-integrity-verify";
+
+const KEY = "per-org-chain-secret";
+
+describe("integrity chain — per-org scoping", () => {
+  it("gives each org an independent, contiguous, standalone-verifiable chain", async () => {
+    const gov = createGovernance({ integrityAudit: { signingKey: KEY } });
+
+    // 3 events for org A, 2 for org B, interleaved in time.
+    await gov.enforce({ agentId: "a1", organizationId: "orgA", action: "tool_call", tool: "t" });
+    await gov.enforce({ agentId: "b1", organizationId: "orgB", action: "tool_call", tool: "t" });
+    await gov.enforce({ agentId: "a1", organizationId: "orgA", action: "tool_call", tool: "t" });
+    await gov.enforce({ agentId: "b1", organizationId: "orgB", action: "tool_call", tool: "t" });
+    await gov.enforce({ agentId: "a1", organizationId: "orgA", action: "tool_call", tool: "t" });
+
+    const chainA = await gov.integrityChain!.export({ organizationId: "orgA" });
+    const chainB = await gov.integrityChain!.export({ organizationId: "orgB" });
+
+    // Each org's slice carries only its own events, with contiguous sequences.
+    assert.equal(chainA.length, 3);
+    assert.equal(chainB.length, 2);
+    assert.deepEqual(chainA.map((e) => e.integrity.sequence), [1, 2, 3]);
+    assert.deepEqual(chainB.map((e) => e.integrity.sequence), [1, 2]);
+    assert.ok(chainA.every((e) => e.organizationId === "orgA"));
+    assert.ok(chainB.every((e) => e.organizationId === "orgB"));
+
+    // Each slice verifies cleanly on its own.
+    const rA = await verifyAuditIntegrity(chainA, KEY);
+    const rB = await verifyAuditIntegrity(chainB, KEY);
+    assert.equal(rA.valid, true, rA.breakDetail ?? "");
+    assert.equal(rB.valid, true, rB.breakDetail ?? "");
+
+    // Heads are tracked per-org.
+    assert.equal(gov.integrityChain!.stats("orgA").latestSequence, 3);
+    assert.equal(gov.integrityChain!.stats("orgB").latestSequence, 2);
+  });
+
+  it("binds organizationId into the hash — relabelling into another org breaks verification", async () => {
+    const gov = createGovernance({ integrityAudit: { signingKey: KEY } });
+    await gov.enforce({ agentId: "a1", organizationId: "orgA", action: "tool_call", tool: "t" });
+    const [event] = await gov.integrityChain!.export({ organizationId: "orgA" });
+
+    // Untampered verifies.
+    assert.equal((await verifyAuditIntegrity([event], KEY)).valid, true);
+
+    // Move the event into another org without re-signing → hash no longer matches.
+    const moved = { ...event, organizationId: "orgB" };
+    const res = await verifyAuditIntegrity([moved], KEY);
+    assert.equal(res.valid, false);
+  });
+
+  it("resolves org from metadata.organizationId when the field is omitted", async () => {
+    const gov = createGovernance({ integrityAudit: { signingKey: KEY } });
+    await gov.enforce({ agentId: "a1", action: "tool_call", tool: "t", metadata: { organizationId: "orgMeta" } });
+
+    const chain = await gov.integrityChain!.export({ organizationId: "orgMeta" });
+    assert.equal(chain.length, 1);
+    assert.equal(chain[0].organizationId, "orgMeta");
+    assert.equal(gov.integrityChain!.stats("orgMeta").latestSequence, 1);
+  });
+
+  it("keeps the org-less chain independent from org chains", async () => {
+    const gov = createGovernance({ integrityAudit: { signingKey: KEY } });
+    await gov.audit.log({ agentId: "x", eventType: "custom", outcome: "success", severity: "info" });
+    await gov.enforce({ agentId: "a1", organizationId: "orgA", action: "tool_call", tool: "t" });
+    await gov.audit.log({ agentId: "x", eventType: "custom", outcome: "success", severity: "info" });
+
+    // org-less chain has its own contiguous sequence (2), unaffected by orgA.
+    const orgless = await gov.integrityChain!.export({});
+    const orglessOnly = orgless.filter((e) => e.organizationId == null);
+    assert.deepEqual(orglessOnly.map((e) => e.integrity.sequence), [1, 2]);
+    assert.equal(gov.integrityChain!.stats().latestSequence, 2);
+    assert.equal(gov.integrityChain!.stats("orgA").latestSequence, 1);
+  });
+
+  it("register() stamps the org onto the agent record and the agent_registered event", async () => {
+    const gov = createGovernance({ integrityAudit: { signingKey: KEY } });
+    const { id } = await gov.register({ name: "alpha", framework: "mastra", owner: "t", organizationId: "orgA" });
+
+    const stored = await gov.storage.getAgent(id);
+    assert.equal(stored?.organizationId, "orgA");
+
+    const chainA = await gov.integrityChain!.export({ organizationId: "orgA" });
+    assert.equal(chainA.length, 1);
+    assert.equal(chainA[0].eventType, "agent_registered");
+    assert.equal((await verifyAuditIntegrity(chainA, KEY)).valid, true);
+  });
+
+  it("recordOutcome() lands on the agent's org chain", async () => {
+    const gov = createGovernance({ integrityAudit: { signingKey: KEY } });
+    await gov.recordOutcome({ agentId: "a1", organizationId: "orgA", action: "tool_call", success: true });
+    const chainA = await gov.integrityChain!.export({ organizationId: "orgA" });
+    assert.equal(chainA.length, 1);
+    assert.equal(chainA[0].eventType, "action_outcome");
+  });
+});

--- a/packages/governance/src/audit-integrity.ts
+++ b/packages/governance/src/audit-integrity.ts
@@ -111,6 +111,12 @@ export function deepSortKeys(value: unknown): unknown {
 /** Compute the canonical string representation of an audit event for hashing */
 export function canonicalize(event: AuditEvent, previousHash: string, sequence: number): string {
   // Deterministic serialization: ALL keys sorted recursively (including nested detail)
+  //
+  // `organizationId` is bound into the hash ONLY when the event carries one.
+  // This cryptographically scopes per-org chains (an event cannot be relabelled
+  // into another org's chain without breaking its hash) while staying byte-for-byte
+  // backward-compatible with org-less chains written before per-org scoping existed
+  // — omitting the key produces the identical canonical form as before.
   const canonical = deepSortKeys({
     agentId: event.agentId,
     createdAt: event.createdAt,
@@ -122,6 +128,7 @@ export function canonicalize(event: AuditEvent, previousHash: string, sequence: 
     previousHash,
     sequence,
     severity: event.severity,
+    ...(event.organizationId != null ? { organizationId: event.organizationId } : {}),
   });
 
   return JSON.stringify(canonical);

--- a/packages/governance/src/index.ts
+++ b/packages/governance/src/index.ts
@@ -55,6 +55,8 @@ import type { GovernanceStorage, StoredAgent, AuditEvent, AuditQueryFilters } fr
  */
 export interface ActionOutcome {
   agentId: string;
+  /** Organization that owns this agent — scopes the audit event to its per-org chain. */
+  organizationId?: string;
   /** The tool / action that ran — matches what was on the EnforcementContext. */
   tool?: string;
   action?: string;
@@ -190,10 +192,17 @@ export interface GovernanceInstance {
    * offline verification via `verifyAuditIntegrity`.
    */
   integrityChain?: {
-    /** Export the full chain (or a filtered slice) as IntegrityAuditEvent[]. */
+    /**
+     * Export the chain as IntegrityAuditEvent[]. Pass `{ organizationId }` in
+     * the filters to export a single org's contiguous, independently-verifiable
+     * chain (chains are scoped per-org).
+     */
     export: (filters?: AuditQueryFilters) => Promise<IntegrityAuditEvent[]>;
-    /** Chain stats: latest sequence, latest hash, algorithm. */
-    stats: () => { latestSequence: number; latestHash: string; algorithm: string };
+    /**
+     * Chain stats for one org (or the org-less chain when omitted):
+     * latest sequence, latest hash, algorithm.
+     */
+    stats: (organizationId?: string) => { latestSequence: number; latestHash: string; algorithm: string };
   };
   audit: {
     log: (event: Omit<AuditEvent, "id" | "createdAt">) => Promise<AuditEvent>;
@@ -280,9 +289,31 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
   // the chain within a single process. Cross-process safety is provided
   // by the UNIQUE index on integrity_sequence at the storage layer.
   const integrity = config.integrityAudit;
-  let chainLastHash = GENESIS_HASH;
-  let chainSequence = 0;
-  let chainLock: Promise<unknown> = Promise.resolve();
+  // Per-org chain state. Each organization gets its OWN hash chain (own head,
+  // own sequence 1..N, own write lock) so one org's audit trail is never
+  // interleaved with another's — an org can export + verify its slice
+  // standalone, and cross-org tampering breaks the chain. Events with no
+  // organizationId share a single sentinel bucket (backward-compatible with
+  // the original global chain).
+  const GLOBAL_CHAIN_KEY = " __global__";
+  interface OrgChainState {
+    lastHash: string;
+    sequence: number;
+    loaded: boolean;
+    loadPromise: Promise<void> | null;
+    /** Serialises writes for THIS org so its sequence is race-free. */
+    lock: Promise<unknown>;
+  }
+  const orgChains = new Map<string, OrgChainState>();
+  function chainStateFor(organizationId: string | undefined): OrgChainState {
+    const key = organizationId ?? GLOBAL_CHAIN_KEY;
+    let state = orgChains.get(key);
+    if (!state) {
+      state = { lastHash: GENESIS_HASH, sequence: 0, loaded: false, loadPromise: null, lock: Promise.resolve() };
+      orgChains.set(key, state);
+    }
+    return state;
+  }
   // Fallback in-memory index for adapters that don't implement
   // createAuditEventWithIntegrity (e.g. third-party 0.11.x adapters).
   // When the storage adapter IS integrity-aware, we don't populate this
@@ -291,23 +322,31 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
   const storageHasIntegrity =
     typeof storage.createAuditEventWithIntegrity === "function" &&
     typeof storage.getAuditIntegrity === "function";
-  let chainHeadLoaded = false;
-  let chainHeadLoadPromise: Promise<void> | null = null;
 
-  async function loadChainHead(): Promise<void> {
-    if (chainHeadLoaded || !integrity) return;
-    if (chainHeadLoadPromise) return chainHeadLoadPromise;
-    chainHeadLoadPromise = (async () => {
+  /** Resolve the org id from an explicit field, falling back to metadata. */
+  function resolveOrgId(
+    explicit: string | undefined,
+    metadata: Record<string, unknown> | undefined,
+  ): string | undefined {
+    if (explicit) return explicit;
+    const fromMeta = metadata?.organizationId;
+    return typeof fromMeta === "string" && fromMeta.length > 0 ? fromMeta : undefined;
+  }
+
+  async function loadChainHead(state: OrgChainState, organizationId: string | undefined): Promise<void> {
+    if (state.loaded || !integrity) return;
+    if (state.loadPromise) return state.loadPromise;
+    state.loadPromise = (async () => {
       if (typeof storage.getChainHead === "function") {
-        const head = await storage.getChainHead();
+        const head = await storage.getChainHead(organizationId);
         if (head) {
-          chainLastHash = head.hash;
-          chainSequence = head.sequence;
+          state.lastHash = head.hash;
+          state.sequence = head.sequence;
         }
       }
-      chainHeadLoaded = true;
+      state.loaded = true;
     })();
-    return chainHeadLoadPromise;
+    return state.loadPromise;
   }
 
   async function writeAudit(
@@ -324,15 +363,18 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
       return storage.createAuditEvent(full);
     }
 
-    // Chained path. Serialise via chainLock so sequence is race-free.
-    // On failure we preserve the chainLastHash/chainSequence (don't bump)
-    // so the next write attempts the same slot — avoids silent gaps.
-    const result = chainLock.then(async () => {
-      // First call after boot: resume chain from durable state, if any.
-      if (!chainHeadLoaded) await loadChainHead();
+    // Chained path. Each org has its own head + lock, so its sequence is
+    // contiguous within the org and independent across orgs. Serialise via
+    // the org's lock so the sequence is race-free. On failure we preserve
+    // the org's lastHash/sequence (don't bump) so the next write attempts
+    // the same slot — avoids silent gaps.
+    const state = chainStateFor(full.organizationId);
+    const result = state.lock.then(async () => {
+      // First call after boot: resume this org's chain from durable state.
+      if (!state.loaded) await loadChainHead(state, full.organizationId);
 
-      const previousHash = chainLastHash;
-      const nextSequence = chainSequence + 1;
+      const previousHash = state.lastHash;
+      const nextSequence = state.sequence + 1;
       const canonical = canonicalizeAuditEvent(full, previousHash, nextSequence);
       const hash = await hmacSha256(integrity.signingKey, canonical);
       const integrityMeta: AuditIntegrity = {
@@ -360,12 +402,12 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
           ),
         );
       }
-      chainLastHash = hash;
-      chainSequence = nextSequence;
+      state.lastHash = hash;
+      state.sequence = nextSequence;
       return stored;
     });
 
-    chainLock = result.catch(() => {
+    state.lock = result.catch(() => {
       /* lock must advance even on failure */
     });
 
@@ -391,6 +433,7 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
     // agent's canonical agentId from lua.skill.yaml so the dashboard
     // record uses the same id the runtime will send to enforce()).
     const id = input.id ?? crypto.randomUUID();
+    const organizationId = resolveOrgId(input.organizationId, input.metadata);
     const assessment = assessAgent(id, input);
 
     // Persist capability booleans in metadata so re-scoring can reconstruct them
@@ -408,6 +451,7 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
       framework: input.framework,
       owner: input.owner,
       description: input.description,
+      organizationId,
       version: input.version ?? "1.0.0",
       channels: input.channels ?? [],
       tools: input.tools ?? [],
@@ -425,6 +469,7 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
     // fire-and-forget for the legacy behaviour.
     const regWrite = writeAudit({
       agentId: id,
+      ...(organizationId ? { organizationId } : {}),
       eventType: "agent_registered",
       outcome: "success",
       severity: "info",
@@ -445,6 +490,7 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
     }
 
     const decision = policies.evaluate(ctx);
+    const organizationId = resolveOrgId(ctx.organizationId, ctx.metadata);
 
     // When integrityAudit is configured, we AWAIT the chain write so
     // sequencing is deterministic (and onFailure:"block" can veto the
@@ -452,6 +498,7 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
     // to stay off the hot path.
     const writePromise = writeAudit({
       agentId: ctx.agentId,
+      ...(organizationId ? { organizationId } : {}),
       eventType: "policy_evaluation",
       outcome: decision.outcome,
       severity: decision.blocked ? "warning" : "info",
@@ -589,9 +636,11 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
     if (remote) return remote.enforce(ctx, stage);
 
     const decision = policies.evaluateStage(ctx, stage);
+    const organizationId = resolveOrgId(ctx.organizationId, ctx.metadata);
 
     const writePromise = writeAudit({
       agentId: ctx.agentId,
+      ...(organizationId ? { organizationId } : {}),
       eventType: `policy_evaluation_${stage}`,
       outcome: decision.outcome,
       severity: decision.blocked ? "warning" : "info",
@@ -657,9 +706,12 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
   const integrityChain = integrity
     ? {
         async export(filters?: AuditQueryFilters): Promise<IntegrityAuditEvent[]> {
-          // Ensure boot-time resume has run so stats()/export() reflect
-          // durable state even if no writes have happened yet.
-          if (!chainHeadLoaded) await loadChainHead();
+          // Ensure boot-time resume has run for the org being exported so
+          // stats()/export() reflect durable state even if no writes have
+          // happened yet this process. Export a single org at a time
+          // (filters.organizationId) to get a contiguous, verifiable chain.
+          const orgState = chainStateFor(filters?.organizationId);
+          if (!orgState.loaded) await loadChainHead(orgState, filters?.organizationId);
           const events = await storage.queryAuditEvents({
             ...filters,
             limit: undefined,
@@ -678,10 +730,11 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
           }
           return result;
         },
-        stats() {
+        stats(organizationId?: string) {
+          const orgState = chainStateFor(organizationId);
           return {
-            latestSequence: chainSequence,
-            latestHash: chainLastHash,
+            latestSequence: orgState.sequence,
+            latestHash: orgState.lastHash,
             algorithm: "hmac-sha256",
           };
         },
@@ -691,6 +744,7 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
   async function recordOutcome(outcome: ActionOutcome): Promise<AuditEvent> {
     return writeAudit({
       agentId: outcome.agentId,
+      ...(outcome.organizationId ? { organizationId: outcome.organizationId } : {}),
       eventType: "action_outcome",
       outcome: outcome.success ? "success" : "failure",
       severity: outcome.success ? "info" : "warning",

--- a/packages/governance/src/policy.ts
+++ b/packages/governance/src/policy.ts
@@ -81,6 +81,13 @@ export interface EnforcementContext {
   agentId: string;
   agentName?: string;
   agentLevel?: number;
+  /**
+   * Organization that owns this agent/request. Used to scope the tamper-evident
+   * audit chain per-org (each org gets an independent HMAC chain) and for
+   * multi-tenant audit queries. Populated by the host; falls back to
+   * `metadata.organizationId` when omitted. Does not affect policy evaluation.
+   */
+  organizationId?: string;
   action: PolicyAction;
   tool?: string;
   input?: Record<string, unknown>;

--- a/packages/governance/src/storage-postgres-schema.ts
+++ b/packages/governance/src/storage-postgres-schema.ts
@@ -70,8 +70,8 @@ export function getSchemaSQL(prefix: string): string {
     CREATE INDEX IF NOT EXISTS idx_${prefix}_agents_org
       ON ${prefix}_agents (organization_id) WHERE organization_id IS NOT NULL;
 
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_${prefix}_audit_integrity_seq
-      ON ${prefix}_audit_events (integrity_sequence) WHERE integrity_sequence IS NOT NULL;
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_${prefix}_audit_integrity_org_seq
+      ON ${prefix}_audit_events (COALESCE(organization_id, ''), integrity_sequence) WHERE integrity_sequence IS NOT NULL;
   `;
 }
 
@@ -166,8 +166,15 @@ export function getIntegrityMigrationSQL(prefix: string): string {
     ALTER TABLE ${prefix}_audit_events ADD COLUMN IF NOT EXISTS integrity_previous_hash TEXT;
     ALTER TABLE ${prefix}_audit_events ADD COLUMN IF NOT EXISTS integrity_sequence BIGINT;
     ALTER TABLE ${prefix}_audit_events ADD COLUMN IF NOT EXISTS integrity_signed_at TIMESTAMPTZ;
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_${prefix}_audit_integrity_seq
-      ON ${prefix}_audit_events (integrity_sequence) WHERE integrity_sequence IS NOT NULL;
+    ALTER TABLE ${prefix}_audit_events ADD COLUMN IF NOT EXISTS organization_id TEXT;
+    -- Chains are scoped per-org: sequence is unique WITHIN an org, not globally.
+    -- Drop the old global unique index and replace with a per-org composite so
+    -- two orgs can both hold sequence=1. COALESCE folds the org-less chain into
+    -- a single '' bucket. Safe + idempotent: existing rows have organization_id
+    -- NULL, so they stay unique under the new index.
+    DROP INDEX IF EXISTS idx_${prefix}_audit_integrity_seq;
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_${prefix}_audit_integrity_org_seq
+      ON ${prefix}_audit_events (COALESCE(organization_id, ''), integrity_sequence) WHERE integrity_sequence IS NOT NULL;
   `;
 }
 

--- a/packages/governance/src/storage-postgres.test.ts
+++ b/packages/governance/src/storage-postgres.test.ts
@@ -407,3 +407,55 @@ describe("PostgreSQL Storage Adapter", () => {
     assert.ok(count >= 2, "should have registration + enforcement events");
   });
 });
+
+describe("PostgreSQL Storage Adapter — organization_id persistence", () => {
+  test("createAgent persists organization_id (roundtrip)", async () => {
+    const pool = createMockPool();
+    const storage = await createPostgresStorage({ pool });
+    await storage.createAgent({
+      id: "org-agent-1",
+      name: "a",
+      framework: "mastra",
+      owner: "team",
+      version: "1.0.0",
+      channels: [],
+      tools: [],
+      compositeScore: 50,
+      governanceLevel: 2,
+      status: "approved",
+      organizationId: "orgA",
+      registeredAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    const got = await storage.getAgent("org-agent-1");
+    assert.equal(got?.organizationId, "orgA");
+  });
+
+  test("createAuditEventWithIntegrity persists organization_id (roundtrip)", async () => {
+    const pool = createMockPool();
+    const storage = await createPostgresStorage({ pool });
+    await storage.createAuditEventWithIntegrity!(
+      {
+        id: "evt-1",
+        agentId: "a1",
+        eventType: "policy_evaluation",
+        outcome: "allow",
+        severity: "info",
+        organizationId: "orgA",
+        createdAt: new Date().toISOString(),
+      },
+      { hash: "h", previousHash: "0".repeat(64), sequence: 1, signedAt: new Date().toISOString() },
+    );
+    const events = await storage.queryAuditEvents({ organizationId: "orgA" });
+    assert.equal(events.length, 1);
+    assert.equal(events[0].organizationId, "orgA");
+  });
+
+  test("getChainHead accepts an organizationId argument", async () => {
+    const pool = createMockPool();
+    const storage = await createPostgresStorage({ pool });
+    // Smoke: the partitioned query runs with the org param bound.
+    const head = await storage.getChainHead!("orgA");
+    assert.equal(head, null);
+  });
+});

--- a/packages/governance/src/storage-postgres.ts
+++ b/packages/governance/src/storage-postgres.ts
@@ -96,8 +96,8 @@ export async function createPostgresStorage(
   async function createAgent(data: StoredAgent): Promise<StoredAgent> {
     await ensureMigrated();
     await pool.query(
-      `INSERT INTO ${prefix}_agents (id,name,framework,owner,description,version,channels,tools,permissions,metadata,composite_score,governance_level,status,registered_at,updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
-      [data.id, data.name, data.framework, data.owner, data.description ?? null, data.version, JSON.stringify(data.channels), JSON.stringify(data.tools), data.permissions ? JSON.stringify(data.permissions) : null, data.metadata ? JSON.stringify(data.metadata) : null, data.compositeScore, data.governanceLevel, data.status, data.registeredAt, data.updatedAt],
+      `INSERT INTO ${prefix}_agents (id,name,framework,owner,description,version,channels,tools,permissions,metadata,composite_score,governance_level,status,organization_id,registered_at,updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
+      [data.id, data.name, data.framework, data.owner, data.description ?? null, data.version, JSON.stringify(data.channels), JSON.stringify(data.tools), data.permissions ? JSON.stringify(data.permissions) : null, data.metadata ? JSON.stringify(data.metadata) : null, data.compositeScore, data.governanceLevel, data.status, data.organizationId ?? null, data.registeredAt, data.updatedAt],
     );
     return data;
   }
@@ -170,8 +170,8 @@ export async function createPostgresStorage(
   async function createAuditEvent(event: AuditEvent): Promise<AuditEvent> {
     await ensureMigrated();
     await pool.query(
-      `INSERT INTO ${prefix}_audit_events (id,agent_id,event_type,outcome,severity,detail,policy_rule_id,created_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
-      [event.id, event.agentId, event.eventType, event.outcome, event.severity, event.detail ? JSON.stringify(event.detail) : null, event.policyRuleId ?? null, event.createdAt],
+      `INSERT INTO ${prefix}_audit_events (id,agent_id,event_type,outcome,severity,detail,policy_rule_id,organization_id,created_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+      [event.id, event.agentId, event.eventType, event.outcome, event.severity, event.detail ? JSON.stringify(event.detail) : null, event.policyRuleId ?? null, event.organizationId ?? null, event.createdAt],
     );
     return event;
   }
@@ -197,7 +197,7 @@ export async function createPostgresStorage(
     // UNIQUE index on integrity_sequence enforces no-duplicates even under
     // concurrent writers (though the chainLock in index.ts already serialises).
     await pool.query(
-      `INSERT INTO ${prefix}_audit_events (id,agent_id,event_type,outcome,severity,detail,policy_rule_id,created_at,integrity_hash,integrity_previous_hash,integrity_sequence,integrity_signed_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+      `INSERT INTO ${prefix}_audit_events (id,agent_id,event_type,outcome,severity,detail,policy_rule_id,organization_id,created_at,integrity_hash,integrity_previous_hash,integrity_sequence,integrity_signed_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
       [
         event.id,
         event.agentId,
@@ -206,6 +206,7 @@ export async function createPostgresStorage(
         event.severity,
         event.detail ? JSON.stringify(event.detail) : null,
         event.policyRuleId ?? null,
+        event.organizationId ?? null,
         event.createdAt,
         integrity.hash,
         integrity.previousHash,
@@ -216,10 +217,13 @@ export async function createPostgresStorage(
     return event;
   }
 
-  async function getChainHead(): Promise<{ sequence: number; hash: string } | null> {
+  async function getChainHead(organizationId?: string): Promise<{ sequence: number; hash: string } | null> {
     await ensureMigrated();
+    // Scope to the org's chain. `IS NOT DISTINCT FROM` matches NULL = NULL so
+    // an undefined org resolves to the org-less chain, not every row.
     const result = await pool.query<{ integrity_sequence: string | number | null; integrity_hash: string | null }>(
-      `SELECT integrity_sequence, integrity_hash FROM ${prefix}_audit_events WHERE integrity_sequence IS NOT NULL ORDER BY integrity_sequence DESC LIMIT 1`,
+      `SELECT integrity_sequence, integrity_hash FROM ${prefix}_audit_events WHERE integrity_sequence IS NOT NULL AND organization_id IS NOT DISTINCT FROM $1 ORDER BY integrity_sequence DESC LIMIT 1`,
+      [organizationId ?? null],
     );
     const row = result.rows[0];
     if (!row || row.integrity_sequence == null || row.integrity_hash == null) return null;

--- a/packages/governance/src/storage.ts
+++ b/packages/governance/src/storage.ts
@@ -45,11 +45,13 @@ export interface GovernanceStorage {
     integrity: StoredAuditIntegrity,
   ): Promise<AuditEvent>;
   /**
-   * Return the latest (highest-sequence) integrity record in storage, or null
-   * if no chained events exist. Called once at createGovernance() startup to
-   * resume the chain across process restarts.
+   * Return the latest (highest-sequence) integrity record for the given org,
+   * or null if that org has no chained events. Chains are scoped per-org, so
+   * pass the `organizationId` to resume the right chain; omit it (or pass
+   * undefined) for the org-less chain. Called lazily on the first write per
+   * org to resume across process restarts.
    */
-  getChainHead?(): Promise<{
+  getChainHead?(organizationId?: string): Promise<{
     sequence: number;
     hash: string;
   } | null>;
@@ -128,7 +130,9 @@ export function createMemoryStorage(): GovernanceStorage {
   const agents: Map<string, StoredAgent> = new Map();
   const events: AuditEvent[] = [];
   const integrity: Map<string, StoredAuditIntegrity> = new Map();
-  let chainHead: { sequence: number; hash: string } | null = null;
+  // Chain head per org (key = organizationId, or "" for the org-less chain).
+  const chainHeads: Map<string, { sequence: number; hash: string }> = new Map();
+  const orgKeyOf = (organizationId?: string) => organizationId ?? "";
 
   return {
     async createAgent(data) {
@@ -197,13 +201,16 @@ export function createMemoryStorage(): GovernanceStorage {
         for (const d of dropped) integrity.delete(d.id);
       }
       integrity.set(event.id, integrityMeta);
-      if (!chainHead || integrityMeta.sequence > chainHead.sequence) {
-        chainHead = { sequence: integrityMeta.sequence, hash: integrityMeta.hash };
+      const key = orgKeyOf(event.organizationId);
+      const head = chainHeads.get(key);
+      if (!head || integrityMeta.sequence > head.sequence) {
+        chainHeads.set(key, { sequence: integrityMeta.sequence, hash: integrityMeta.hash });
       }
       return event;
     },
-    async getChainHead() {
-      return chainHead ? { ...chainHead } : null;
+    async getChainHead(organizationId?: string) {
+      const head = chainHeads.get(orgKeyOf(organizationId));
+      return head ? { ...head } : null;
     },
     async getAuditIntegrity(eventId) {
       const meta = integrity.get(eventId);

--- a/packages/governance/src/types.ts
+++ b/packages/governance/src/types.ts
@@ -85,6 +85,8 @@ export interface AgentRegistration {
   framework: AgentFramework;
   description?: string;
   owner: string;
+  /** Organization that owns this agent — scopes audit + per-org chain. */
+  organizationId?: string;
   version?: string;
   channels?: string[];
   tools?: string[];


### PR DESCRIPTION
## What

Scopes the SDK's tamper-evident HMAC audit chain **per organization**. Before this, one `createGovernance({ integrityAudit })` instance kept a single global chain, so every org's events interleaved into one chain + sequence space — no clean per-tenant verifiable export, and one tenant's volume affected another's chain.

Now each `organizationId` gets its own head, its own `1..N` sequence, and its own write lock. Events with no org share one org-less chain, **byte-for-byte compatible** with pre-0.18 chains (no migration needed).

## Changes

- `EnforcementContext`/`AgentRegistration`/`ActionOutcome` gain `organizationId`; `enforce()`/`enforceStage()` also fall back to `metadata.organizationId`.
- `canonicalize()` binds `organizationId` into the per-event hash **only when present** → org-less events hash exactly as before; an event can't be relabelled into another org's chain without breaking verification.
- Per-org chain state + per-org write lock in `createGovernance()`; `loadChainHead(orgId)` resume.
- `GovernanceStorage.getChainHead(organizationId?)` (memory + Postgres adapters).
- Postgres adapter now **persists `organization_id`** on agents + audit events (columns/indexes existed but were never written), and the `integrity_sequence` unique index is now per-org `(COALESCE(organization_id,''), integrity_sequence)`. Integrity migration swaps the old global unique index for the composite one (idempotent, safe on existing rows).
- `integrityChain.stats(orgId?)` / `export({ organizationId })` operate on a single org's chain.

## Tests

- New `audit-chain-per-org.test.ts` (6 cases: isolation, contiguous per-org sequences, standalone verify, org-from-metadata, org-less independence, register/recordOutcome stamping, cross-org relabel detection).
- Postgres adapter org_id roundtrip tests.
- Full suite: **1425 pass / 0 fail**; `tsc --noEmit` clean; `npm run build` clean.

## Release

Version bumped to **0.18.0** with CHANGELOG + README (synced). Merge → tag `v0.18.0` → `publish.yml` publishes to npm + creates the GitHub Release from the CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches audit integrity hashing, chain resume, and Postgres uniqueness constraints—important for compliance evidence, but additive with org-less backward compatibility and broad test coverage.
> 
> **Overview**
> **0.18.0** scopes the HMAC integrity audit chain **per `organizationId`** instead of one global interleaved chain. Each tenant gets its own head, `1..N` sequence, and write lock; `integrityChain.export({ organizationId })` and `stats(organizationId?)` target one contiguous, independently verifiable slice.
> 
> Callers pass **`organizationId`** on `EnforcementContext`, `AgentRegistration`, and `ActionOutcome` (with **`metadata.organizationId`** fallback on enforce paths). **`canonicalize()`** includes `organizationId` in the event hash only when set, so org-less events stay byte-compatible with pre-0.18 chains while relabelling an event across orgs fails verification.
> 
> **`createGovernance()`** replaces a single chain with per-org state and per-org locks; **`GovernanceStorage.getChainHead(organizationId?)`** resumes the correct chain after restart (memory + Postgres). The Postgres adapter **writes `organization_id`** on agents and audit rows and swaps the integrity unique index to **`(COALESCE(organization_id,''), integrity_sequence)`** via an idempotent migration.
> 
> Docs/CHANGELOG and **`audit-chain-per-org.test.ts`** cover multi-tenant isolation; version bumped to **0.18.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 455ddb46c08821037cf0352bf117cb6c54985525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->