### PR TITLE
fix: multi-process-safe audit integrity chain via atomic per-org append

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,12 @@ is exactly what it does and does not do:
   `integrityAudit: { signingKey }` for tamper-evident audit. Since 0.12
   the chain is persisted durably (survives process restart) when the
   storage adapter supports `createAuditEventWithIntegrity` (memory and
-  Postgres adapters both do). HMAC chains are still only tamper-evident
-  to holders of the signing secret — rotate and pair with an external
-  anchor if you need adversary-grade non-repudiation.
+  Postgres adapters both do). Since 0.18.2 that chain is also
+  **multi-process-safe** when the adapter implements `appendToAuditChain`
+  (Postgres) — see [Multi-process deployments](#multi-process-deployments).
+  HMAC chains are still only tamper-evident to holders of the signing
+  secret — rotate and pair with an external anchor if you need
+  adversary-grade non-repudiation.
 - **Cloud `register()` is a synthetic confirmation** — the API auto-registers
   on first `enforce()`.
 - **No built-in red team / jailbreak harness.** Use inspect-ai, PyRIT, or
@@ -452,6 +455,62 @@ didn't invoke `enforce()` or `recordOutcome()` itself.
   creates a chain gap that `verifyAuditIntegrity` will detect; set
   `'block'` to reject the enforce() call instead when you can't tolerate
   gaps.
+
+#### Multi-process deployments
+
+If more than one process writes to the **same audit store** — Kubernetes
+replicas, a `pm2` cluster, or serverless instances all pointed at one
+Postgres database — the chain must allocate each event's `sequence` and
+`previousHash` from the **current durable head**, not from process-local
+state. Otherwise two processes derive the same sequence for the same org
+(one `INSERT` wins, the other is dropped by the unique index) and their
+per-process `previousHash` forks the chain.
+
+This is the job of the optional storage-contract method
+`appendToAuditChain(event, computeIntegrity)`. The adapter, under a per-org
+lock that spans the whole operation, reads the org's durable head, calls back
+into the SDK to compute the HMAC (the signing key never leaves the SDK core),
+and persists the event + integrity as one indivisible write:
+
+```typescript
+import { createGovernance } from 'governance-sdk';
+import { createPostgresStorage } from 'governance-sdk/storage-postgres';
+
+const gov = createGovernance({
+  storage: await createPostgresStorage({ pool }), // pg.Pool — real transactions
+  integrityAudit: { signingKey: process.env.AUDIT_SECRET! },
+});
+// Every process using this config appends atomically against the shared DB —
+// no duplicate-sequence drops, no per-process chain fork.
+```
+
+`createGovernance()` uses `appendToAuditChain` automatically whenever the
+storage adapter provides it. **Support by shipped adapter:**
+
+| Adapter | `appendToAuditChain` | Multi-process safe? |
+|---|---|---|
+| **Postgres** (`createPostgresStorage`) | ✅ per-org `pg_advisory_xact_lock` transaction (falls back to a bounded `23505`-retry loop for query-only pools) | ✅ across processes sharing the database |
+| **Memory** (`createMemoryStorage`) | ✅ per-org in-process async lock | Single process **by design** — memory is not shared across processes |
+| Third-party adapter without the method | — | Falls back to the legacy process-local-sequence path (correct under a **single writer** only) |
+
+**Custom storage adapters:** to be multi-process-safe, implement
+`appendToAuditChain` so the head-read → compute → insert sequence is atomic
+against concurrent writers (a row lock, an advisory lock, a serializable
+transaction, or a compare-and-set retry on your uniqueness constraint). If you
+can't, leave it unimplemented and run a single writer — the SDK falls back
+safely and warns.
+
+**The standalone `createIntegrityAudit()` wrapper is single-process only.** It
+keeps its chain in process memory and never persists integrity metadata, so it
+forks across processes and loses verifiability across restarts. Use it for
+prototyping and tests; use `createGovernance({ integrityAudit })` (above) for
+durable, multi-process audit.
+
+**Rolling deploys:** the lock only protects writers that take it. During a
+mixed-version window (some processes pre-0.18.2), the old processes still
+allocate from process-local counters and can collide with or fork past the
+locked writers. Replace all writers together and expect residual
+unique-violation warnings until the last old process drains.
 
 ### Kill Switch
 

--- a/packages/governance/CHANGELOG.md
+++ b/packages/governance/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [0.18.2] - 2026-07-15 — Multi-pod-safe audit integrity chain
+## [0.18.2] - 2026-07-15 — Multi-process-safe audit integrity chain
 
 Fixes silent audit-event loss and hash-chain forking when the integrity audit
-(`integrityAudit`) runs behind more than one process (e.g. multiple pods
-sharing one Postgres database).
+(`integrityAudit`) runs behind more than one process (e.g. multiple replicas, a
+`pm2` cluster, or serverless instances sharing one Postgres database).
 
 Previously the chain's `sequence` and `previousHash` were held as
 process-local state, resumed from the durable head only once at boot. Every
@@ -62,7 +62,7 @@ Backward compatible: the canonical hash form, per-org scoping, `verify()`,
   the HMAC-covered `sequence` (wall-clock `createdAt` only tiebreaks) instead
   of `createdAt`-first. `createdAt` is stamped before the append lock, so
   under concurrent writers a lower sequence can carry a later timestamp
-  (lock-wait inversion, cross-pod clock skew) — the old ordering could report
+  (lock-wait inversion, cross-process clock skew) — the old ordering could report
   a valid multi-writer chain as tampered. Sequence ordering is tamper-safe:
   the sequence is inside the signed hash, so forging it still breaks the
   hash/previous-hash checks.
@@ -73,12 +73,18 @@ Backward compatible: the canonical hash form, per-org scoping, `verify()`,
 ### Notes
 
 - `integrityChain.stats()` still reports this process's last-written sequence
-  and hash (a process-local cache), so it can lag another pod's writes. The
+  and hash (a process-local cache), so it can lag another process's writes. The
   durable chain is authoritative; `export()` + `verifyAuditIntegrity()` read
-  from storage. A DB-backed `stats()`/`verify()` is a candidate follow-up.
+  from storage. A DB-backed `stats()` is deferred (it would change the method
+  from sync to async — a breaking signature change); tracked in #39.
 - The standalone `createIntegrityAudit()` wrapper in `audit-integrity.ts`
-  retains its pure in-process module-state chain and is not covered by this
-  fix — it is not the path `createGovernance({ integrityAudit })` uses.
+  keeps its chain in process memory and is **single-process only** — it is a
+  separate, in-memory construct from the durable
+  `createGovernance({ integrityAudit })` path this fix hardens (the wrapper
+  holds no storage handle to append against). It now carries a prominent
+  single-process warning in its JSDoc and the README "Multi-process
+  deployments" note; use `createGovernance({ integrityAudit })` for durable,
+  multi-process audit.
 - Rolling deploys: the advisory lock only protects writers that take it.
   During a mixed-version window, pre-0.18.2 processes still allocate from
   their process-local counters and can collide with or fork past locked

--- a/packages/governance/CHANGELOG.md
+++ b/packages/governance/CHANGELOG.md
@@ -69,6 +69,17 @@ Backward compatible: the canonical hash form, per-org scoping, `verify()`,
 - On the transactional append path, a failed `ROLLBACK` now destroys the
   pooled connection (`client.release(err)`) instead of returning a dead or
   aborted-transaction client to the pool.
+- `integrityChain.export()` / `verifyAuditIntegrity()` now read durable
+  integrity whenever the adapter implements `getAuditIntegrity`, no longer
+  gating that read on the legacy `createAuditEventWithIntegrity`. An adapter
+  implementing the new `appendToAuditChain` write contract plus
+  `getAuditIntegrity` (but not the legacy write method) previously exported an
+  empty chain even though its writes persisted integrity durably.
+- A storage adapter with durable integrity but no `appendToAuditChain` now
+  emits a one-time `onAuditError` advisory: it uses process-local sequence
+  allocation, which is multi-process-safe only under a single writer. The
+  README's "falls back safely and warns" guidance previously held only for the
+  older session-local (no `createAuditEventWithIntegrity`) fallback.
 
 ### Notes
 

--- a/packages/governance/CHANGELOG.md
+++ b/packages/governance/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## [0.18.2] - 2026-07-15 — Multi-pod-safe audit integrity chain
+
+Fixes silent audit-event loss and hash-chain forking when the integrity audit
+(`integrityAudit`) runs behind more than one process (e.g. multiple pods
+sharing one Postgres database).
+
+Previously the chain's `sequence` and `previousHash` were held as
+process-local state, resumed from the durable head only once at boot. Every
+process then advanced its own counter independently, so two processes derived
+the same sequence for the same org — one `INSERT` won and the other lost to
+the `UNIQUE (COALESCE(organization_id,''), integrity_sequence)` index
+(Postgres `23505`), dropping that governance decision's tamper-evident record.
+Even without a collision the per-process `previousHash` forked the chain.
+
+Sequence allocation and previous-hash derivation are now atomic **against the
+database, per org**: the storage adapter reads the current head, derives the
+HMAC, and inserts — all under a per-org lock — on every write. No consumer
+code change is required beyond upgrading; `createGovernance({ integrityAudit })`
+picks up the safe path automatically.
+
+Backward compatible: the canonical hash form, per-org scoping, `verify()`,
+`export()`, and `stats()` are unchanged.
+
+### Added
+
+- `GovernanceStorage.appendToAuditChain(event, computeIntegrity)` — atomically
+  reads the org's durable head, invokes `computeIntegrity(head)` (the signing
+  key stays in the SDK core), and persists event + integrity as one operation.
+  Implemented by the memory adapter (per-org async lock) and the Postgres
+  adapter.
+- Postgres path uses a transaction with `pg_advisory_xact_lock(hashtext(org))`
+  → head `SELECT` → `INSERT` → `COMMIT`, serialising each org's chain against
+  itself across all writers (unrelated orgs proceed in parallel).
+- `PgClientLike` type and an optional `connect()` on `PgPoolLike` for the
+  transactional path. Pools exposing only `query()` fall back to a bounded
+  read-head → insert → retry-on-`23505` loop, which is also multi-writer-safe.
+
+### Changed
+
+- `createGovernance()` prefers `appendToAuditChain` when the storage adapter
+  provides it; the previous `createAuditEventWithIntegrity` + process-local
+  sequence path remains only as a fallback for third-party adapters that
+  predate this method (correct under a single writer).
+
+### Notes
+
+- `integrityChain.stats()` still reports this process's last-written sequence
+  and hash (a process-local cache), so it can lag another pod's writes. The
+  durable chain is authoritative; `export()` + `verifyAuditIntegrity()` read
+  from storage. A DB-backed `stats()`/`verify()` is a candidate follow-up.
+- The standalone `createIntegrityAudit()` wrapper in `audit-integrity.ts`
+  retains its pure in-process module-state chain and is not covered by this
+  fix — it is not the path `createGovernance({ integrityAudit })` uses.
+
 ## [0.18.1] - 2026-06-26 — Evasion-resistant injection normalization
 
 Hardens `detectInjection()` against obfuscated prompt-injection attacks that

--- a/packages/governance/CHANGELOG.md
+++ b/packages/governance/CHANGELOG.md
@@ -30,9 +30,12 @@ Backward compatible: the canonical hash form, per-org scoping, `verify()`,
   key stays in the SDK core), and persists event + integrity as one operation.
   Implemented by the memory adapter (per-org async lock) and the Postgres
   adapter.
-- Postgres path uses a transaction with `pg_advisory_xact_lock(hashtext(org))`
-  → head `SELECT` → `INSERT` → `COMMIT`, serialising each org's chain against
-  itself across all writers (unrelated orgs proceed in parallel).
+- Postgres path uses a transaction with
+  `pg_advisory_xact_lock(<classid>, hashtext(org))` → head `SELECT` → `INSERT`
+  → `COMMIT`, serialising each org's chain against itself across all writers
+  (unrelated orgs proceed in parallel). The two-arg lock form namespaces the
+  key under a fixed classid so other advisory-lock users of the same database
+  can't contend with the audit chain.
 - `PgClientLike` type and an optional `connect()` on `PgPoolLike` for the
   transactional path. Pools exposing only `query()` fall back to a bounded
   read-head → insert → retry-on-`23505` loop, which is also multi-writer-safe.
@@ -43,6 +46,26 @@ Backward compatible: the canonical hash form, per-org scoping, `verify()`,
   provides it; the previous `createAuditEventWithIntegrity` + process-local
   sequence path remains only as a fallback for third-party adapters that
   predate this method (correct under a single writer).
+- The Postgres chain-head `SELECT` now scopes by `COALESCE(organization_id,'')`
+  — the exact partition of the unique index and the advisory-lock key — so the
+  head read can never disagree with the uniqueness/lock scope (a literal-`''`
+  org and the org-less chain were previously read as different heads while
+  colliding on the same index partition). Matching the index expression also
+  lets the head read walk the unique index directly.
+
+### Fixed
+
+- `verifyAuditIntegrity()` and `integrityChain.export()` now order entries by
+  the HMAC-covered `sequence` (wall-clock `createdAt` only tiebreaks) instead
+  of `createdAt`-first. `createdAt` is stamped before the append lock, so
+  under concurrent writers a lower sequence can carry a later timestamp
+  (lock-wait inversion, cross-pod clock skew) — the old ordering could report
+  a valid multi-writer chain as tampered. Sequence ordering is tamper-safe:
+  the sequence is inside the signed hash, so forging it still breaks the
+  hash/previous-hash checks.
+- On the transactional append path, a failed `ROLLBACK` now destroys the
+  pooled connection (`client.release(err)`) instead of returning a dead or
+  aborted-transaction client to the pool.
 
 ### Notes
 
@@ -53,6 +76,11 @@ Backward compatible: the canonical hash form, per-org scoping, `verify()`,
 - The standalone `createIntegrityAudit()` wrapper in `audit-integrity.ts`
   retains its pure in-process module-state chain and is not covered by this
   fix — it is not the path `createGovernance({ integrityAudit })` uses.
+- Rolling deploys: the advisory lock only protects writers that take it.
+  During a mixed-version window, pre-0.18.2 processes still allocate from
+  their process-local counters and can collide with or fork past locked
+  writers. Replace all writers together; expect residual unique-violation
+  warnings until the last old process drains.
 
 ## [0.18.1] - 2026-06-26 — Evasion-resistant injection normalization
 

--- a/packages/governance/CHANGELOG.md
+++ b/packages/governance/CHANGELOG.md
@@ -38,7 +38,10 @@ Backward compatible: the canonical hash form, per-org scoping, `verify()`,
   can't contend with the audit chain.
 - `PgClientLike` type and an optional `connect()` on `PgPoolLike` for the
   transactional path. Pools exposing only `query()` fall back to a bounded
-  read-head → insert → retry-on-`23505` loop, which is also multi-writer-safe.
+  read-head → insert → retry-on-`23505` loop with jittered backoff, which is
+  also multi-writer-safe: every unique-violation means a competitor committed
+  the derived sequence, so a writer loses at most once per concurrent same-org
+  contender (the retry cap absorbs 12-way same-instant contention).
 
 ### Changed
 

--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -79,9 +79,12 @@ is exactly what it does and does not do:
   `integrityAudit: { signingKey }` for tamper-evident audit. Since 0.12
   the chain is persisted durably (survives process restart) when the
   storage adapter supports `createAuditEventWithIntegrity` (memory and
-  Postgres adapters both do). HMAC chains are still only tamper-evident
-  to holders of the signing secret — rotate and pair with an external
-  anchor if you need adversary-grade non-repudiation.
+  Postgres adapters both do). Since 0.18.2 that chain is also
+  **multi-process-safe** when the adapter implements `appendToAuditChain`
+  (Postgres) — see [Multi-process deployments](#multi-process-deployments).
+  HMAC chains are still only tamper-evident to holders of the signing
+  secret — rotate and pair with an external anchor if you need
+  adversary-grade non-repudiation.
 - **Cloud `register()` is a synthetic confirmation** — the API auto-registers
   on first `enforce()`.
 - **No built-in red team / jailbreak harness.** Use inspect-ai, PyRIT, or
@@ -452,6 +455,62 @@ didn't invoke `enforce()` or `recordOutcome()` itself.
   creates a chain gap that `verifyAuditIntegrity` will detect; set
   `'block'` to reject the enforce() call instead when you can't tolerate
   gaps.
+
+#### Multi-process deployments
+
+If more than one process writes to the **same audit store** — Kubernetes
+replicas, a `pm2` cluster, or serverless instances all pointed at one
+Postgres database — the chain must allocate each event's `sequence` and
+`previousHash` from the **current durable head**, not from process-local
+state. Otherwise two processes derive the same sequence for the same org
+(one `INSERT` wins, the other is dropped by the unique index) and their
+per-process `previousHash` forks the chain.
+
+This is the job of the optional storage-contract method
+`appendToAuditChain(event, computeIntegrity)`. The adapter, under a per-org
+lock that spans the whole operation, reads the org's durable head, calls back
+into the SDK to compute the HMAC (the signing key never leaves the SDK core),
+and persists the event + integrity as one indivisible write:
+
+```typescript
+import { createGovernance } from 'governance-sdk';
+import { createPostgresStorage } from 'governance-sdk/storage-postgres';
+
+const gov = createGovernance({
+  storage: await createPostgresStorage({ pool }), // pg.Pool — real transactions
+  integrityAudit: { signingKey: process.env.AUDIT_SECRET! },
+});
+// Every process using this config appends atomically against the shared DB —
+// no duplicate-sequence drops, no per-process chain fork.
+```
+
+`createGovernance()` uses `appendToAuditChain` automatically whenever the
+storage adapter provides it. **Support by shipped adapter:**
+
+| Adapter | `appendToAuditChain` | Multi-process safe? |
+|---|---|---|
+| **Postgres** (`createPostgresStorage`) | ✅ per-org `pg_advisory_xact_lock` transaction (falls back to a bounded `23505`-retry loop for query-only pools) | ✅ across processes sharing the database |
+| **Memory** (`createMemoryStorage`) | ✅ per-org in-process async lock | Single process **by design** — memory is not shared across processes |
+| Third-party adapter without the method | — | Falls back to the legacy process-local-sequence path (correct under a **single writer** only) |
+
+**Custom storage adapters:** to be multi-process-safe, implement
+`appendToAuditChain` so the head-read → compute → insert sequence is atomic
+against concurrent writers (a row lock, an advisory lock, a serializable
+transaction, or a compare-and-set retry on your uniqueness constraint). If you
+can't, leave it unimplemented and run a single writer — the SDK falls back
+safely and warns.
+
+**The standalone `createIntegrityAudit()` wrapper is single-process only.** It
+keeps its chain in process memory and never persists integrity metadata, so it
+forks across processes and loses verifiability across restarts. Use it for
+prototyping and tests; use `createGovernance({ integrityAudit })` (above) for
+durable, multi-process audit.
+
+**Rolling deploys:** the lock only protects writers that take it. During a
+mixed-version window (some processes pre-0.18.2), the old processes still
+allocate from process-local counters and can collide with or fork past the
+locked writers. Replace all writers together and expect residual
+unique-violation warnings until the last old process drains.
 
 ### Kill Switch
 

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "governance-sdk",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "AI Agent Governance for TypeScript — policy enforcement, scoring, compliance, and audit for AI agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/governance/src/audit-chain-append-postgres.test.ts
+++ b/packages/governance/src/audit-chain-append-postgres.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Postgres adapter — atomic appendToAuditChain.
+ *
+ * Exercises the adapter's transactional path (BEGIN → pg_advisory_xact_lock →
+ * SELECT head → INSERT → COMMIT) and its retry fallback for pools without a
+ * transaction handle.
+ *
+ * NOTE ON FIDELITY: the mock models `pg_advisory_xact_lock` as an in-process
+ * async mutex over a shared rows array, so it reproduces the SERIALISATION the
+ * lock provides and lets us assert the orchestration end-to-end. It does NOT
+ * prove Postgres itself serialises across real connections — that is a Postgres
+ * guarantee, not something a mock can establish. Two assertions here are
+ * therefore split: (1) SQL SHAPE — the exact statement sequence the adapter
+ * emits; (2) ORCHESTRATION — contiguous sequences under the modelled lock.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createPostgresStorage } from "./storage-postgres";
+import type { PgPoolLike, PgClientLike } from "./storage-postgres";
+import { createGovernance } from "./index";
+import { verifyAuditIntegrity } from "./audit-integrity-verify";
+
+const KEY = "pg-append-secret";
+
+interface AuditRowShape {
+  organization_id: string | null;
+  integrity_sequence: number;
+  integrity_hash: string;
+  [k: string]: unknown;
+}
+
+/**
+ * Postgres pool mock with a working `connect()`, an in-process advisory-lock
+ * mutex, a shared audit table, and the per-org unique (org, sequence) index.
+ */
+function createTxnPool(opts: { clientLog?: string[] } = {}): PgPoolLike {
+  const rows: AuditRowShape[] = [];
+  const locks = new Map<string, Promise<void>>();
+  const orgKey = (org: string | null | undefined) => org ?? "";
+
+  function headFor(org: string | null): { rows: unknown[] } {
+    const matching = rows.filter((r) => orgKey(r.organization_id) === orgKey(org));
+    if (matching.length === 0) return { rows: [] };
+    const top = matching.reduce((a, b) => (b.integrity_sequence > a.integrity_sequence ? b : a));
+    return { rows: [{ integrity_sequence: top.integrity_sequence, integrity_hash: top.integrity_hash }] };
+  }
+
+  function insert(values: unknown[]): void {
+    // Column order from auditIntegrityInsertSQL.
+    const org = values[7] as string | null;
+    const sequence = values[11] as number;
+    if (rows.some((r) => orgKey(r.organization_id) === orgKey(org) && r.integrity_sequence === sequence)) {
+      throw Object.assign(new Error("duplicate key value violates unique constraint"), { code: "23505" });
+    }
+    rows.push({
+      id: values[0] as string,
+      agent_id: values[1],
+      event_type: values[2],
+      outcome: values[3],
+      severity: values[4],
+      detail: values[5] != null ? JSON.parse(values[5] as string) : null,
+      policy_rule_id: values[6],
+      organization_id: org,
+      created_at: values[8],
+      integrity_hash: values[9] as string,
+      integrity_previous_hash: values[10],
+      integrity_sequence: sequence,
+      integrity_signed_at: values[12],
+    });
+  }
+
+  async function runQuery(text: string, values: unknown[] | undefined, log?: string[]) {
+    const t = text.trim();
+    if (log) log.push(t.split(/\s+/).slice(0, 2).join(" "));
+    if (t.startsWith("BEGIN") || t.startsWith("COMMIT") || t.startsWith("ROLLBACK")) {
+      return { rows: [], rowCount: 0 };
+    }
+    if (t.includes("CREATE TABLE") || t.includes("CREATE INDEX") || t.includes("ALTER TABLE") || t.includes("DROP INDEX")) {
+      return { rows: [], rowCount: 0 };
+    }
+    if (t.includes("pg_advisory_xact_lock")) {
+      return { rows: [], rowCount: 0 }; // handled by the client wrapper
+    }
+    if (t.startsWith("SELECT") && t.includes("integrity_sequence IS NOT NULL")) {
+      return headFor((values?.[0] as string) ?? null) as { rows: never[]; rowCount: number };
+    }
+    // getAuditIntegrity(eventId): SELECT integrity_* ... WHERE id = $1
+    if (t.startsWith("SELECT integrity_hash")) {
+      const row = rows.find((r) => r.id === values?.[0]);
+      return { rows: row ? [row] : [], rowCount: row ? 1 : 0 } as { rows: never[]; rowCount: number };
+    }
+    // queryAuditEvents: SELECT * FROM ... [WHERE organization_id = $1] ORDER BY created_at DESC
+    if (t.startsWith("SELECT * FROM")) {
+      const org = t.includes("organization_id = $1") ? (values?.[0] as string) : undefined;
+      const out = (org !== undefined ? rows.filter((r) => r.organization_id === org) : [...rows]);
+      return { rows: out, rowCount: out.length } as unknown as { rows: never[]; rowCount: number };
+    }
+    if (t.startsWith("INSERT")) {
+      insert(values ?? []);
+      return { rows: [], rowCount: 1 };
+    }
+    return { rows: [], rowCount: 0 };
+  }
+
+  return {
+    async query(text: string, values?: unknown[]) {
+      return runQuery(text, values) as never;
+    },
+    async connect(): Promise<PgClientLike> {
+      let releaseLock: (() => void) | null = null;
+      const log = opts.clientLog;
+      return {
+        async query(text: string, values?: unknown[]) {
+          const t = text.trim();
+          if (t.includes("pg_advisory_xact_lock")) {
+            const key = orgKey(values?.[0] as string);
+            const prev = locks.get(key) ?? Promise.resolve();
+            let resolveMine!: () => void;
+            const mine = new Promise<void>((r) => { resolveMine = r; });
+            locks.set(key, prev.then(() => mine));
+            await prev; // block until the previous holder releases
+            releaseLock = resolveMine;
+            if (log) log.push("SELECT pg_advisory_xact_lock");
+            return { rows: [], rowCount: 0 } as never;
+          }
+          const res = await runQuery(text, values, log);
+          if (t.startsWith("COMMIT") || t.startsWith("ROLLBACK")) {
+            releaseLock?.();
+            releaseLock = null;
+          }
+          return res as never;
+        },
+        release() {
+          // Safety net: release the lock if COMMIT/ROLLBACK didn't run.
+          releaseLock?.();
+          releaseLock = null;
+        },
+      };
+    },
+    async end() {},
+  };
+}
+
+describe("postgres appendToAuditChain — transactional path", () => {
+  it("emits BEGIN → advisory-lock → head SELECT → INSERT → COMMIT in order (SQL shape)", async () => {
+    const clientLog: string[] = [];
+    const pool = createTxnPool({ clientLog });
+    const storage = await createPostgresStorage({ pool, autoMigrate: true });
+
+    await storage.appendToAuditChain!(
+      { id: "e1", agentId: "a", eventType: "t", outcome: "allow", severity: "info", organizationId: "org1", createdAt: new Date().toISOString() },
+      async (head) => ({ hash: "h1", previousHash: head?.hash ?? "0".repeat(64), sequence: (head?.sequence ?? 0) + 1, signedAt: new Date().toISOString() }),
+    );
+
+    assert.deepEqual(clientLog, ["BEGIN ISOLATION", "SELECT pg_advisory_xact_lock", "SELECT integrity_sequence,", "INSERT INTO", "COMMIT"]);
+  });
+
+  it("derives sequence + previousHash from the DB head across sequential appends", async () => {
+    const pool = createTxnPool();
+    const storage = await createPostgresStorage({ pool, autoMigrate: true });
+    const seen: Array<{ prev: string; seq: number }> = [];
+
+    for (let i = 0; i < 3; i++) {
+      await storage.appendToAuditChain!(
+        { id: `e${i}`, agentId: "a", eventType: "t", outcome: "allow", severity: "info", organizationId: "org1", createdAt: new Date().toISOString() },
+        async (head) => {
+          const meta = { hash: `hash${i}`, previousHash: head?.hash ?? "GENESIS", sequence: (head?.sequence ?? 0) + 1, signedAt: new Date().toISOString() };
+          seen.push({ prev: meta.previousHash, seq: meta.sequence });
+          return meta;
+        },
+      );
+    }
+
+    // Each write saw the prior write's committed head — sequences 1,2,3 and
+    // previousHash links to the last row's hash (not a process-local guess).
+    assert.deepEqual(seen.map((s) => s.seq), [1, 2, 3]);
+    assert.deepEqual(seen.map((s) => s.prev), ["GENESIS", "hash0", "hash1"]);
+  });
+
+  it("interleaves two governance instances over one pool into a contiguous chain (orchestration)", async () => {
+    const pool = createTxnPool();
+    const storage = await createPostgresStorage({ pool, autoMigrate: true });
+    const podA = createGovernance({ storage, integrityAudit: { signingKey: KEY } });
+    const podB = createGovernance({ storage, integrityAudit: { signingKey: KEY } });
+
+    const N = 30;
+    const writes: Promise<unknown>[] = [];
+    for (let i = 0; i < N; i++) {
+      writes.push((i % 2 ? podB : podA).enforce({ agentId: `a${i}`, organizationId: "orgP", action: "tool_call", tool: "t" }));
+    }
+    await Promise.all(writes);
+
+    const chain = await podA.integrityChain!.export({ organizationId: "orgP" });
+    assert.equal(chain.length, N);
+    const sequences = chain.map((e) => e.integrity.sequence).sort((a, b) => a - b);
+    assert.deepEqual(sequences, Array.from({ length: N }, (_, i) => i + 1));
+    const result = await verifyAuditIntegrity(chain, KEY);
+    assert.equal(result.valid, true, result.breakDetail ?? "invalid");
+  });
+});
+
+describe("postgres appendToAuditChain — retry fallback (no connect())", () => {
+  it("recovers from a unique-violation by re-reading the head and retrying", async () => {
+    // A query-only pool (no connect) exercises the retry path. Simulate a
+    // stale first attempt: a competing row lands at sequence 1 before our
+    // INSERT, so the first insert 23505s and the retry re-reads head → seq 2.
+    const rows: AuditRowShape[] = [];
+    let firstInsert = true;
+    const pool: PgPoolLike = {
+      async query(text: string, values?: unknown[]) {
+        const t = text.trim();
+        if (t.includes("CREATE") || t.includes("ALTER") || t.includes("DROP INDEX")) return { rows: [], rowCount: 0 } as never;
+        if (t.startsWith("SELECT") && t.includes("integrity_sequence IS NOT NULL")) {
+          if (rows.length === 0) return { rows: [], rowCount: 0 } as never;
+          const top = rows.reduce((a, b) => (b.integrity_sequence > a.integrity_sequence ? b : a));
+          return { rows: [{ integrity_sequence: top.integrity_sequence, integrity_hash: top.integrity_hash }], rowCount: 1 } as never;
+        }
+        if (t.startsWith("INSERT")) {
+          const seq = values![11] as number;
+          if (firstInsert) {
+            firstInsert = false;
+            // A competitor grabbed sequence 1 first.
+            rows.push({ organization_id: null, integrity_sequence: 1, integrity_hash: "competitor" });
+          }
+          if (rows.some((r) => r.integrity_sequence === seq)) {
+            throw Object.assign(new Error("duplicate"), { code: "23505" });
+          }
+          rows.push({ organization_id: values![7] as string | null, integrity_sequence: seq, integrity_hash: values![9] as string });
+          return { rows: [], rowCount: 1 } as never;
+        }
+        return { rows: [], rowCount: 0 } as never;
+      },
+      async end() {},
+    };
+
+    const storage = await createPostgresStorage({ pool, autoMigrate: true });
+    const attempts: number[] = [];
+    const { integrity } = await storage.appendToAuditChain!(
+      { id: "e1", agentId: "a", eventType: "t", outcome: "allow", severity: "info", createdAt: new Date().toISOString() },
+      async (head) => {
+        const seq = (head?.sequence ?? 0) + 1;
+        attempts.push(seq);
+        return { hash: "mine", previousHash: head?.hash ?? "GEN", sequence: seq, signedAt: new Date().toISOString() };
+      },
+    );
+
+    // First attempt derived seq 1 (empty head) → 23505; retry saw the
+    // competitor's row and derived seq 2 with prevHash = competitor's hash.
+    assert.deepEqual(attempts, [1, 2]);
+    assert.equal(integrity.sequence, 2);
+    assert.equal(integrity.previousHash, "competitor");
+  });
+});

--- a/packages/governance/src/audit-chain-append-postgres.test.ts
+++ b/packages/governance/src/audit-chain-append-postgres.test.ts
@@ -252,6 +252,49 @@ describe("postgres appendToAuditChain — retry fallback (no connect())", () => 
     assert.equal(integrity.sequence, 2);
     assert.equal(integrity.previousHash, "competitor");
   });
+
+  it("absorbs N-way same-org contention without dropping a write", async () => {
+    // Every 23505 means a competitor committed the derived sequence, so a
+    // writer loses at most once per concurrent contender: with 10 writers and
+    // MAX_ATTEMPTS=12 completion is guaranteed, not probabilistic.
+    const rows: AuditRowShape[] = [];
+    const pool: PgPoolLike = {
+      async query(text: string, values?: unknown[]) {
+        const t = text.trim();
+        if (t.includes("CREATE") || t.includes("ALTER") || t.includes("DROP INDEX")) return { rows: [], rowCount: 0 } as never;
+        if (t.startsWith("SELECT") && t.includes("integrity_sequence IS NOT NULL")) {
+          if (rows.length === 0) return { rows: [], rowCount: 0 } as never;
+          const top = rows.reduce((a, b) => (b.integrity_sequence > a.integrity_sequence ? b : a));
+          return { rows: [{ integrity_sequence: top.integrity_sequence, integrity_hash: top.integrity_hash }], rowCount: 1 } as never;
+        }
+        if (t.startsWith("INSERT")) {
+          const seq = values![11] as number;
+          if (rows.some((r) => r.integrity_sequence === seq)) {
+            throw Object.assign(new Error("duplicate"), { code: "23505" });
+          }
+          rows.push({ organization_id: values![7] as string | null, integrity_sequence: seq, integrity_hash: values![9] as string });
+          return { rows: [], rowCount: 1 } as never;
+        }
+        return { rows: [], rowCount: 0 } as never;
+      },
+      async end() {},
+    };
+
+    const storage = await createPostgresStorage({ pool, autoMigrate: true });
+    const N = 10;
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        storage.appendToAuditChain!(
+          { id: `e${i}`, agentId: `a${i}`, eventType: "t", outcome: "allow", severity: "info", organizationId: "orgC", createdAt: new Date().toISOString() },
+          async (head) => ({ hash: `h${i}`, previousHash: head?.hash ?? "GEN", sequence: (head?.sequence ?? 0) + 1, signedAt: new Date().toISOString() }),
+        ),
+      ),
+    );
+
+    assert.equal(rows.length, N);
+    const sequences = rows.map((r) => r.integrity_sequence).sort((a, b) => a - b);
+    assert.deepEqual(sequences, Array.from({ length: N }, (_, i) => i + 1));
+  });
 });
 
 describe("postgres appendToAuditChain — connection hygiene on failure", () => {

--- a/packages/governance/src/audit-chain-append-postgres.test.ts
+++ b/packages/governance/src/audit-chain-append-postgres.test.ts
@@ -114,7 +114,8 @@ function createTxnPool(opts: { clientLog?: string[] } = {}): PgPoolLike {
         async query(text: string, values?: unknown[]) {
           const t = text.trim();
           if (t.includes("pg_advisory_xact_lock")) {
-            const key = orgKey(values?.[0] as string);
+            // Two-arg form: values[0] = lock classid, values[1] = org key.
+            const key = orgKey(values?.[1] as string);
             const prev = locks.get(key) ?? Promise.resolve();
             let resolveMine!: () => void;
             const mine = new Promise<void>((r) => { resolveMine = r; });
@@ -250,5 +251,59 @@ describe("postgres appendToAuditChain — retry fallback (no connect())", () => 
     assert.deepEqual(attempts, [1, 2]);
     assert.equal(integrity.sequence, 2);
     assert.equal(integrity.previousHash, "competitor");
+  });
+});
+
+describe("postgres appendToAuditChain — connection hygiene on failure", () => {
+  function failingPool(opts: { rollbackFails: boolean; releaseArgs: unknown[][]; insertErr: Error; rollbackErr: Error }): PgPoolLike {
+    return {
+      async query() {
+        return { rows: [], rowCount: 0 } as never; // migrations
+      },
+      async connect(): Promise<PgClientLike> {
+        return {
+          async query(text: string) {
+            const t = text.trim();
+            if (t.startsWith("INSERT")) throw opts.insertErr;
+            if (t.startsWith("ROLLBACK") && opts.rollbackFails) throw opts.rollbackErr;
+            return { rows: [], rowCount: 0 } as never;
+          },
+          release(...args: unknown[]) {
+            opts.releaseArgs.push(args);
+          },
+        };
+      },
+      async end() {},
+    };
+  }
+
+  const auditEvent = { id: "e1", agentId: "a", eventType: "t", outcome: "allow" as const, severity: "info", createdAt: new Date().toISOString() };
+  const compute = async () => ({ hash: "h", previousHash: "0".repeat(64), sequence: 1, signedAt: new Date().toISOString() });
+
+  it("destroys the client — release(err) — when ROLLBACK fails after a failed write", async () => {
+    const releaseArgs: unknown[][] = [];
+    const insertErr = Object.assign(new Error("insert exploded"), { code: "XX000" });
+    const rollbackErr = new Error("connection terminated");
+    const pool = failingPool({ rollbackFails: true, releaseArgs, insertErr, rollbackErr });
+
+    const storage = await createPostgresStorage({ pool, autoMigrate: true });
+    await assert.rejects(storage.appendToAuditChain!(auditEvent, compute), insertErr);
+
+    // Released exactly once, WITH the rollback error → pool destroys the
+    // connection instead of handing an aborted/dead one to the next caller.
+    assert.equal(releaseArgs.length, 1);
+    assert.equal(releaseArgs[0][0], rollbackErr);
+  });
+
+  it("releases the client cleanly when ROLLBACK succeeds", async () => {
+    const releaseArgs: unknown[][] = [];
+    const insertErr = Object.assign(new Error("insert exploded"), { code: "XX000" });
+    const pool = failingPool({ rollbackFails: false, releaseArgs, insertErr, rollbackErr: new Error("unused") });
+
+    const storage = await createPostgresStorage({ pool, autoMigrate: true });
+    await assert.rejects(storage.appendToAuditChain!(auditEvent, compute), insertErr);
+
+    assert.equal(releaseArgs.length, 1);
+    assert.equal(releaseArgs[0][0], undefined);
   });
 });

--- a/packages/governance/src/audit-chain-multiwriter.test.ts
+++ b/packages/governance/src/audit-chain-multiwriter.test.ts
@@ -15,7 +15,10 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { createGovernance } from "./index";
 import { createMemoryStorage } from "./storage";
+import type { AuditEvent } from "./storage";
 import { verifyAuditIntegrity } from "./audit-integrity-verify";
+import { GENESIS_HASH, canonicalize, hmacSha256 } from "./audit-integrity";
+import type { AuditIntegrity, IntegrityAuditEvent } from "./audit-integrity";
 
 const KEY = "multi-writer-secret";
 
@@ -73,5 +76,57 @@ describe("integrity chain — multi-writer (shared storage, two instances)", () 
       const result = await verifyAuditIntegrity(chain, KEY);
       assert.equal(result.valid, true, `${org}: ${result.breakDetail ?? "invalid"}`);
     }
+  });
+});
+
+describe("integrity chain — wall-clock order disagrees with chain order", () => {
+  // createdAt is stamped BEFORE the append lock allocates the sequence, so
+  // under concurrent writers (lock-wait inversion) or cross-pod clock skew a
+  // lower sequence can carry a LATER timestamp. The chain order is the
+  // sequence — verification and export must not key on wall clock.
+  async function chainedEvent(
+    i: number,
+    createdAt: string,
+    prev: AuditIntegrity | null,
+  ): Promise<IntegrityAuditEvent> {
+    const event: AuditEvent = {
+      id: `evt-${i}`,
+      agentId: `a${i}`,
+      eventType: "tool_call",
+      outcome: "allow",
+      severity: "info",
+      organizationId: "orgSkew",
+      createdAt,
+    };
+    const previousHash = prev?.hash ?? GENESIS_HASH;
+    const sequence = (prev?.sequence ?? 0) + 1;
+    const hash = await hmacSha256(KEY, canonicalize(event, previousHash, sequence));
+    return { ...event, integrity: { hash, previousHash, sequence, signedAt: createdAt } };
+  }
+
+  it("verifies a chain whose createdAt order inverts its sequence order", async () => {
+    // The seq-1 writer stamped its clock LAST: it entered writeAudit first
+    // but won the lock ahead of two writers with earlier-running clocks.
+    const e1 = await chainedEvent(1, "2026-07-15T10:00:00.150Z", null);
+    const e2 = await chainedEvent(2, "2026-07-15T10:00:00.100Z", e1.integrity);
+    const e3 = await chainedEvent(3, "2026-07-15T10:00:00.125Z", e2.integrity);
+
+    const result = await verifyAuditIntegrity([e1, e2, e3], KEY);
+    assert.equal(result.valid, true, result.breakDetail ?? "timestamp-skewed chain must verify");
+  });
+
+  it("export() orders by sequence, not createdAt", async () => {
+    const storage = createMemoryStorage();
+    const e1 = await chainedEvent(1, "2026-07-15T10:00:00.150Z", null);
+    const e2 = await chainedEvent(2, "2026-07-15T10:00:00.100Z", e1.integrity);
+    for (const { integrity, ...event } of [e1, e2]) {
+      await storage.createAuditEventWithIntegrity!(event, integrity);
+    }
+
+    const gov = createGovernance({ storage, integrityAudit: { signingKey: KEY } });
+    const chain = await gov.integrityChain!.export({ organizationId: "orgSkew" });
+    assert.deepEqual(chain.map((e) => e.integrity.sequence), [1, 2]);
+    const result = await verifyAuditIntegrity(chain, KEY);
+    assert.equal(result.valid, true, result.breakDetail ?? "exported chain must verify");
   });
 });

--- a/packages/governance/src/audit-chain-multiwriter.test.ts
+++ b/packages/governance/src/audit-chain-multiwriter.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Multi-writer integrity audit chain tests.
+ *
+ * The chain state (sequence + previous-hash) is NOT process-local: it is
+ * allocated atomically from the durable head on every write. Two separate
+ * governance instances sharing ONE storage backend simulate two pods sharing
+ * one database. Without atomic head-derivation each instance keeps its own
+ * boot-time counter, both emit sequence 1, 2, 3…, and they either collide on
+ * the unique (org, sequence) index (dropped events) or fork the hash chain.
+ * With atomic head-derivation the writes interleave into a single contiguous,
+ * standalone-verifiable chain.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createGovernance } from "./index";
+import { createMemoryStorage } from "./storage";
+import { verifyAuditIntegrity } from "./audit-integrity-verify";
+
+const KEY = "multi-writer-secret";
+
+describe("integrity chain — multi-writer (shared storage, two instances)", () => {
+  it("interleaves N concurrent writes from two pods into one contiguous, valid chain", async () => {
+    // One shared backend = one database. Two instances = two pods.
+    const storage = createMemoryStorage();
+    const podA = createGovernance({ storage, integrityAudit: { signingKey: KEY } });
+    const podB = createGovernance({ storage, integrityAudit: { signingKey: KEY } });
+
+    const N = 40;
+    const writes: Promise<unknown>[] = [];
+    for (let i = 0; i < N; i++) {
+      const pod = i % 2 === 0 ? podA : podB;
+      writes.push(
+        pod.enforce({ agentId: `a${i}`, organizationId: "orgX", action: "tool_call", tool: "t" }),
+      );
+    }
+    await Promise.all(writes);
+
+    const chain = await podA.integrityChain!.export({ organizationId: "orgX" });
+
+    // Exactly N events — nothing dropped on a sequence collision.
+    assert.equal(chain.length, N, `expected ${N} events, got ${chain.length} (dropped writes?)`);
+
+    // Sequences are a contiguous 1..N with no duplicates and no gaps.
+    const sequences = chain.map((e) => e.integrity.sequence).sort((a, b) => a - b);
+    assert.deepEqual(sequences, Array.from({ length: N }, (_, i) => i + 1));
+
+    // The single interleaved chain verifies standalone.
+    const result = await verifyAuditIntegrity(chain, KEY);
+    assert.equal(result.valid, true, result.breakDetail ?? "chain did not verify");
+  });
+
+  it("keeps each org's chain contiguous when two pods write to two orgs at once", async () => {
+    const storage = createMemoryStorage();
+    const podA = createGovernance({ storage, integrityAudit: { signingKey: KEY } });
+    const podB = createGovernance({ storage, integrityAudit: { signingKey: KEY } });
+
+    const perOrg = 15;
+    const writes: Promise<unknown>[] = [];
+    for (let i = 0; i < perOrg; i++) {
+      writes.push(podA.enforce({ agentId: "a", organizationId: "orgA", action: "tool_call", tool: "t" }));
+      writes.push(podB.enforce({ agentId: "b", organizationId: "orgA", action: "tool_call", tool: "t" }));
+      writes.push(podA.enforce({ agentId: "c", organizationId: "orgB", action: "tool_call", tool: "t" }));
+      writes.push(podB.enforce({ agentId: "d", organizationId: "orgB", action: "tool_call", tool: "t" }));
+    }
+    await Promise.all(writes);
+
+    for (const org of ["orgA", "orgB"]) {
+      const chain = await podA.integrityChain!.export({ organizationId: org });
+      assert.equal(chain.length, perOrg * 2, `${org}: expected ${perOrg * 2} events`);
+      const sequences = chain.map((e) => e.integrity.sequence).sort((a, b) => a - b);
+      assert.deepEqual(sequences, Array.from({ length: perOrg * 2 }, (_, i) => i + 1), `${org}: sequences`);
+      const result = await verifyAuditIntegrity(chain, KEY);
+      assert.equal(result.valid, true, `${org}: ${result.breakDetail ?? "invalid"}`);
+    }
+  });
+});

--- a/packages/governance/src/audit-chain-partial-adapter.test.ts
+++ b/packages/governance/src/audit-chain-partial-adapter.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Partial-adapter capability detection for the integrity chain.
+ *
+ * A custom storage adapter may implement only a SUBSET of the integrity
+ * contract. Two subsets that shipped adapters never exercise (Postgres +
+ * memory implement everything) but that the multi-process README actively
+ * encourages custom adapters to adopt:
+ *
+ *   1. appendToAuditChain + getAuditIntegrity, WITHOUT the legacy
+ *      createAuditEventWithIntegrity. Writes persist durable integrity via the
+ *      new atomic-append contract; export()/verify() must read it back through
+ *      getAuditIntegrity rather than an empty in-process index.
+ *   2. createAuditEventWithIntegrity + getAuditIntegrity, WITHOUT
+ *      appendToAuditChain. Durable but process-local sequence allocation —
+ *      only safe under a single writer. The SDK must emit the documented
+ *      one-time advisory so multi-process deployments aren't silently unsafe.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createGovernance, createMemoryStorage } from "./index.js";
+import { verifyAuditIntegrity } from "./audit-integrity-verify.js";
+import type { GovernanceStorage } from "./storage.js";
+
+const KEY = "partial-adapter-test-secret";
+
+async function writeN(gov: Awaited<ReturnType<typeof createGovernance>>, count: number) {
+  for (let i = 0; i < count; i++) {
+    await gov.audit.log({
+      agentId: "partial-agent",
+      eventType: "test_event",
+      outcome: "success",
+      severity: "info",
+      detail: { iteration: i },
+    });
+  }
+}
+
+/** Core (non-integrity) storage surface, copied from a memory base. */
+function coreSurface(base: GovernanceStorage) {
+  return {
+    createAgent: base.createAgent,
+    getAgent: base.getAgent,
+    getAgentByName: base.getAgentByName,
+    listAgents: base.listAgents,
+    updateAgent: base.updateAgent,
+    deleteAgent: base.deleteAgent,
+    createAuditEvent: base.createAuditEvent,
+    queryAuditEvents: base.queryAuditEvents,
+    countAuditEvents: base.countAuditEvents,
+  };
+}
+
+describe("integrity chain — partial storage adapters", () => {
+  it("exports + verifies for an appendToAuditChain-only adapter (no createAuditEventWithIntegrity)", async () => {
+    const base = createMemoryStorage();
+    // New write contract + durable read, but NO legacy write method.
+    const atomicOnly: GovernanceStorage = {
+      ...coreSurface(base),
+      appendToAuditChain: base.appendToAuditChain,
+      getChainHead: base.getChainHead,
+      getAuditIntegrity: base.getAuditIntegrity,
+      // intentionally omit: createAuditEventWithIntegrity
+    };
+
+    const gov = createGovernance({ storage: atomicOnly, integrityAudit: { signingKey: KEY } });
+    await writeN(gov, 4);
+
+    const chain = await gov.integrityChain!.export();
+    assert.equal(chain.length, 4, "export must read durable integrity via getAuditIntegrity");
+    assert.deepEqual(
+      chain.map((e) => e.integrity.sequence),
+      [1, 2, 3, 4],
+      "sequences are contiguous",
+    );
+    const verification = await verifyAuditIntegrity(chain, KEY);
+    assert.equal(verification.valid, true, verification.breakDetail ?? "chain should verify");
+    assert.equal(verification.eventsVerified, 4);
+  });
+
+  it("warns once for a durable adapter without appendToAuditChain, and still exports + verifies", async () => {
+    const base = createMemoryStorage();
+    // Durable integrity via the legacy write method, but NO atomic append.
+    const durableNoAtomic: GovernanceStorage = {
+      ...coreSurface(base),
+      createAuditEventWithIntegrity: base.createAuditEventWithIntegrity,
+      getChainHead: base.getChainHead,
+      getAuditIntegrity: base.getAuditIntegrity,
+      // intentionally omit: appendToAuditChain
+    };
+
+    const warnings: Error[] = [];
+    const gov = createGovernance({
+      storage: durableNoAtomic,
+      integrityAudit: { signingKey: KEY },
+      onAuditError: (e) => warnings.push(e as Error),
+    });
+
+    await writeN(gov, 3);
+
+    const nonAtomicWarnings = warnings.filter(
+      (w) => w instanceof Error && /appendToAuditChain/.test(w.message),
+    );
+    assert.equal(
+      nonAtomicWarnings.length,
+      1,
+      "process-local fallback warns exactly once (not per write)",
+    );
+    assert.match(nonAtomicWarnings[0].message, /single writer/);
+
+    const chain = await gov.integrityChain!.export();
+    assert.equal(chain.length, 3, "durable path still persists + exports the chain");
+    const verification = await verifyAuditIntegrity(chain, KEY);
+    assert.equal(verification.valid, true, verification.breakDetail ?? "chain should verify");
+  });
+});

--- a/packages/governance/src/audit-integrity-adversarial.test.ts
+++ b/packages/governance/src/audit-integrity-adversarial.test.ts
@@ -53,7 +53,7 @@ describe("audit integrity — adversarial scenarios", () => {
   });
 
   it("detects reorder attempt: renumbering sequences to mask a swap breaks the hash", async () => {
-    // The verifier sorts by (createdAt, sequence) before checking, so a raw
+    // The verifier sorts by sequence before checking, so a raw
     // array reorder re-sorts back to canonical order. An attacker wanting to
     // actually reorder the chain would have to edit the sequence numbers and
     // previousHash fields — doing so breaks the signed hash. This test

--- a/packages/governance/src/audit-integrity-verify.ts
+++ b/packages/governance/src/audit-integrity-verify.ts
@@ -32,10 +32,17 @@ export async function verifyAuditIntegrity(
   entries: IntegrityAuditEvent[],
   signingKey: string,
 ): Promise<ChainVerificationResult> {
+  // Order by sequence, not createdAt: the sequence is allocated under the
+  // chain's write lock and is HMAC-covered, so it IS the chain order. Wall
+  // clocks are stamped before the lock and can disagree with it (lock-wait
+  // inversion under concurrent writers, cross-process clock skew) — sorting
+  // by createdAt would report a valid chain as tampered. A forged sequence
+  // still fails the hash/previousHash checks below.
   const sorted = [...entries].sort((a, b) => {
-    const t = a.createdAt.localeCompare(b.createdAt);
-    if (t !== 0) return t;
-    return a.integrity.sequence - b.integrity.sequence;
+    const sa = a.integrity?.sequence;
+    const sb = b.integrity?.sequence;
+    if (sa != null && sb != null && sa !== sb) return sa - sb;
+    return a.createdAt.localeCompare(b.createdAt);
   });
 
   let currentPreviousHash = GENESIS_HASH;

--- a/packages/governance/src/audit-integrity.test.ts
+++ b/packages/governance/src/audit-integrity.test.ts
@@ -209,4 +209,26 @@ describe("Tamper-Evident Audit (EU AI Act Article 12)", () => {
     // Even with same content, different keys = different hashes
     assert.notEqual(e1.integrity.hash, e2.integrity.hash);
   });
+
+  // Documents the wrapper's single-process boundary (see its JSDoc + the
+  // README "Multi-process deployments" note): the chain lives in process
+  // memory, so a second wrapper over the SAME governance/storage starts its
+  // own sequence at 1 and forks — it does NOT resume the durable head. The
+  // multi-process-safe path is createGovernance({ integrityAudit }).
+  it("keeps its chain in-process — a second wrapper over the same governance forks (single-process by design)", async () => {
+    const gov = createGovernance({});
+    const first = createIntegrityAudit(gov, { signingKey: TEST_KEY });
+    const second = createIntegrityAudit(gov, { signingKey: TEST_KEY });
+
+    const a1 = await first.log({ agentId: "agent-1", eventType: "tool_call", outcome: "success", severity: "info" });
+    const a2 = await first.log({ agentId: "agent-1", eventType: "tool_call", outcome: "success", severity: "info" });
+    assert.equal(a1.integrity.sequence, 1);
+    assert.equal(a2.integrity.sequence, 2);
+
+    // A separate wrapper does not observe `first`'s in-memory head — it starts
+    // its own chain at genesis rather than continuing from sequence 2.
+    const b1 = await second.log({ agentId: "agent-1", eventType: "tool_call", outcome: "success", severity: "info" });
+    assert.equal(b1.integrity.sequence, 1);
+    assert.equal(b1.integrity.previousHash, "0".repeat(64));
+  });
 });

--- a/packages/governance/src/audit-integrity.ts
+++ b/packages/governance/src/audit-integrity.ts
@@ -146,6 +146,29 @@ export const GENESIS_HASH = "0".repeat(64); // Initial chain hash
  * an immutable chain. Any tampering is immediately detectable.
  *
  * Satisfies EU AI Act Article 12 logging integrity requirements.
+ *
+ * ---
+ *
+ * ⚠️ **Single-process / single-session only.** This wrapper keeps its chain
+ * (`sequence`, last hash, and the per-event integrity map) in **process
+ * memory**. It never persists integrity metadata and never reads the durable
+ * chain head, so:
+ *
+ *   - Two processes (multiple replicas, a `pm2` cluster, serverless instances)
+ *     each start their own `sequence` at 1 and fork the chain.
+ *   - A restart loses the in-memory map, so events written before the restart
+ *     can no longer be verified.
+ *
+ * For **durable, multi-process-safe** tamper-evident audit, use
+ * `createGovernance({ integrityAudit: { signingKey } })` with a storage adapter
+ * that implements `appendToAuditChain` (the built-in Postgres adapter does).
+ * That path allocates the sequence and previous-hash atomically from the
+ * durable per-org head under a storage-level lock, so concurrent writers —
+ * including separate processes sharing one database — never collide or fork.
+ * See the "Multi-process deployments" note in the README.
+ *
+ * This standalone wrapper remains useful for in-memory prototyping, tests, and
+ * genuinely single-process tools where a self-contained chain is enough.
  */
 export function createIntegrityAudit(
   governance: GovernanceInstance,

--- a/packages/governance/src/index.ts
+++ b/packages/governance/src/index.ts
@@ -744,9 +744,8 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
             limit: undefined,
             offset: undefined,
           });
-          const sorted = [...events].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
           const result: IntegrityAuditEvent[] = [];
-          for (const e of sorted) {
+          for (const e of events) {
             // Prefer durable integrity record; fall back to in-memory
             // index for adapters that don't yet persist it.
             const durable = storageHasIntegrity
@@ -755,7 +754,15 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
             const meta = durable ?? integrityIndex.get(e.id);
             if (meta) result.push({ ...e, integrity: meta });
           }
-          return result;
+          // Chain order is the lock-allocated sequence, not wall clock —
+          // createdAt is stamped before the write lock and can invert under
+          // concurrent writers. createdAt only tiebreaks legacy forked rows.
+          return result.sort((a, b) => {
+            if (a.integrity.sequence !== b.integrity.sequence) {
+              return a.integrity.sequence - b.integrity.sequence;
+            }
+            return a.createdAt.localeCompare(b.createdAt);
+          });
         },
         stats(organizationId?: string) {
           const orgState = chainStateFor(organizationId);

--- a/packages/governance/src/index.ts
+++ b/packages/governance/src/index.ts
@@ -322,10 +322,19 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
   const storageHasIntegrity =
     typeof storage.createAuditEventWithIntegrity === "function" &&
     typeof storage.getAuditIntegrity === "function";
+  // Durable integrity READS only need getAuditIntegrity — an adapter can
+  // implement the newer appendToAuditChain write contract + getAuditIntegrity
+  // without the legacy createAuditEventWithIntegrity. export()/verify() must
+  // still read that durable integrity rather than the (empty) in-process index.
+  const storageCanReadIntegrity = typeof storage.getAuditIntegrity === "function";
   // Multi-writer-safe path: the adapter allocates the sequence + previous-hash
   // from the durable head atomically (per-org lock), so concurrent processes
   // never fork the chain or collide on a sequence. Preferred when available.
   const storageHasAtomicAppend = typeof storage.appendToAuditChain === "function";
+  // One-time advisory: an adapter with durable integrity but no atomic append
+  // uses process-local sequence allocation, which is only safe under a single
+  // writer. Signalled once so multi-process deployments aren't silently unsafe.
+  let warnedNonAtomicAppend = false;
 
   /** Resolve the org id from an explicit field, falling back to metadata. */
   function resolveOrgId(
@@ -395,6 +404,20 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
         state.sequence = integrityMeta.sequence;
         state.loaded = true;
         return stored;
+      }
+
+      // Process-local sequence path (no appendToAuditChain). Correct under a
+      // SINGLE writer only. Warn once so custom adapters in multi-process
+      // deployments get the documented signal. (The pure-legacy branch below
+      // additionally warns per-write about the non-durable session-local
+      // downgrade — a strictly more severe, data-losing failure mode.)
+      if (storageHasIntegrity && !warnedNonAtomicAppend) {
+        warnedNonAtomicAppend = true;
+        onAuditError?.(
+          new Error(
+            "integrity chain: storage adapter implements createAuditEventWithIntegrity but not appendToAuditChain; audit appends use process-local sequence allocation and are multi-process-safe only under a single writer — implement appendToAuditChain for atomic cross-process appends",
+          ),
+        );
       }
 
       // First call after boot: resume this org's chain from durable state.
@@ -748,7 +771,7 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
           for (const e of events) {
             // Prefer durable integrity record; fall back to in-memory
             // index for adapters that don't yet persist it.
-            const durable = storageHasIntegrity
+            const durable = storageCanReadIntegrity
               ? await storage.getAuditIntegrity!(e.id)
               : null;
             const meta = durable ?? integrityIndex.get(e.id);

--- a/packages/governance/src/index.ts
+++ b/packages/governance/src/index.ts
@@ -322,6 +322,10 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
   const storageHasIntegrity =
     typeof storage.createAuditEventWithIntegrity === "function" &&
     typeof storage.getAuditIntegrity === "function";
+  // Multi-writer-safe path: the adapter allocates the sequence + previous-hash
+  // from the durable head atomically (per-org lock), so concurrent processes
+  // never fork the chain or collide on a sequence. Preferred when available.
+  const storageHasAtomicAppend = typeof storage.appendToAuditChain === "function";
 
   /** Resolve the org id from an explicit field, falling back to metadata. */
   function resolveOrgId(
@@ -370,6 +374,29 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
     // the same slot — avoids silent gaps.
     const state = chainStateFor(full.organizationId);
     const result = state.lock.then(async () => {
+      // Preferred: the storage adapter allocates the sequence + previous-hash
+      // from the CURRENT durable head atomically, so this is safe across pods.
+      // The in-process `state.lock` above still serialises this pod's writes to
+      // the org (cheap local ordering ahead of the DB lock); `state.*` is only
+      // refreshed afterwards as a cache for stats(), never read to derive the
+      // next slot.
+      if (storageHasAtomicAppend) {
+        const { event: stored, integrity: integrityMeta } = await storage.appendToAuditChain!(
+          full,
+          async (head) => {
+            const previousHash = head?.hash ?? GENESIS_HASH;
+            const nextSequence = (head?.sequence ?? 0) + 1;
+            const canonical = canonicalizeAuditEvent(full, previousHash, nextSequence);
+            const hash = await hmacSha256(integrity.signingKey, canonical);
+            return { hash, previousHash, sequence: nextSequence, signedAt: new Date().toISOString() };
+          },
+        );
+        state.lastHash = integrityMeta.hash;
+        state.sequence = integrityMeta.sequence;
+        state.loaded = true;
+        return stored;
+      }
+
       // First call after boot: resume this org's chain from durable state.
       if (!state.loaded) await loadChainHead(state, full.organizationId);
 

--- a/packages/governance/src/storage-postgres.ts
+++ b/packages/governance/src/storage-postgres.ts
@@ -220,7 +220,7 @@ export async function createPostgresStorage(
     await ensureMigrated();
     const result = await pool.query<{ integrity_sequence: string | number | null; integrity_hash: string | null }>(
       chainHeadSQL(prefix),
-      [organizationId ?? null],
+      [organizationId ?? ""],
     );
     return parseChainHeadRow(result.rows[0]);
   }
@@ -248,24 +248,35 @@ export async function createPostgresStorage(
         // lock is granted), the head read goes stale, and the same sequence is
         // re-derived → 23505. Pin it so a server/role default can't break us.
         await client.query("BEGIN ISOLATION LEVEL READ COMMITTED");
-        // pg_advisory_xact_lock auto-releases at COMMIT/ROLLBACK. The org-less
-        // chain uses the empty string, matching the COALESCE(organization_id,'')
-        // partition of the unique index.
-        await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [event.organizationId ?? ""]);
+        // pg_advisory_xact_lock auto-releases at COMMIT/ROLLBACK. The two-arg
+        // form namespaces the key under AUDIT_CHAIN_LOCK_CLASS so other
+        // advisory-lock users of the same database can't contend with us. The
+        // org-less chain uses the empty string, matching the
+        // COALESCE(organization_id,'') partition of the unique index.
+        await client.query("SELECT pg_advisory_xact_lock($1, hashtext($2))", [
+          AUDIT_CHAIN_LOCK_CLASS,
+          event.organizationId ?? "",
+        ]);
         const headRes = await client.query<{ integrity_sequence: string | number | null; integrity_hash: string | null }>(
           chainHeadSQL(prefix),
-          [event.organizationId ?? null],
+          [event.organizationId ?? ""],
         );
         const head = parseChainHeadRow(headRes.rows[0]);
         const integrity = await computeIntegrity(head);
         await client.query(auditIntegrityInsertSQL(prefix), auditIntegrityInsertParams(event, integrity));
         await client.query("COMMIT");
+        client.release();
         return { event, integrity };
       } catch (err) {
-        await client.query("ROLLBACK").catch(() => undefined);
+        try {
+          await client.query("ROLLBACK");
+          client.release();
+        } catch (rollbackErr) {
+          // ROLLBACK failing means the connection is dead or wedged in an
+          // aborted transaction — destroy it rather than poison the pool.
+          client.release(rollbackErr);
+        }
         throw err;
-      } finally {
-        client.release();
       }
     }
 
@@ -359,11 +370,21 @@ function auditIntegrityInsertParams(event: AuditEvent, integrity: StoredAuditInt
   ];
 }
 
+/**
+ * Advisory-lock namespace (int4) for audit-chain appends — the classid of the
+ * two-arg pg_advisory_xact_lock form. Arbitrary but fixed: it only has to be
+ * distinct from any other advisory-lock user of the same database.
+ */
+const AUDIT_CHAIN_LOCK_CLASS = 0x67764143;
+
 /** SELECT for the highest-sequence integrity row of one org's chain. */
 function chainHeadSQL(prefix: string): string {
-  // `IS NOT DISTINCT FROM` matches NULL = NULL so an undefined org resolves to
-  // the org-less chain, not every row.
-  return `SELECT integrity_sequence, integrity_hash FROM ${prefix}_audit_events WHERE integrity_sequence IS NOT NULL AND organization_id IS NOT DISTINCT FROM $1 ORDER BY integrity_sequence DESC LIMIT 1`;
+  // COALESCE(organization_id,'') is the exact partition of the unique index
+  // and the advisory-lock key: NULL and '' orgs are one chain everywhere, so
+  // the head read can never disagree with the uniqueness/lock scope. Bind the
+  // org-less chain as ''. Matching the index expression also lets this LIMIT 1
+  // walk the unique index directly.
+  return `SELECT integrity_sequence, integrity_hash FROM ${prefix}_audit_events WHERE integrity_sequence IS NOT NULL AND COALESCE(organization_id, '') = $1 ORDER BY integrity_sequence DESC LIMIT 1`;
 }
 
 /** Coerce a chain-head row (pg returns BIGINT as string) into typed head or null. */

--- a/packages/governance/src/storage-postgres.ts
+++ b/packages/governance/src/storage-postgres.ts
@@ -11,12 +11,27 @@ import type { AgentRow, AuditRow } from "./storage-postgres-schema.js";
 
 // ─── Types ──────────────────────────────────────────────────────
 
+/** Minimal pg.PoolClient-compatible interface (a single checked-out connection) */
+export interface PgClientLike {
+  query<R = Record<string, unknown>>(
+    text: string,
+    values?: unknown[],
+  ): Promise<{ rows: R[]; rowCount: number | null }>;
+  release(err?: unknown): void;
+}
+
 /** Minimal pg.Pool-compatible interface */
 export interface PgPoolLike {
   query<R = Record<string, unknown>>(
     text: string,
     values?: unknown[],
   ): Promise<{ rows: R[]; rowCount: number | null }>;
+  /**
+   * Check out a dedicated connection for a transaction. Present on real
+   * pg.Pool; optional here so lightweight/mock pools that only implement
+   * query() still satisfy the interface (they use the retry fallback).
+   */
+  connect?(): Promise<PgClientLike>;
   end(): Promise<void>;
 }
 
@@ -193,45 +208,83 @@ export async function createPostgresStorage(
   ): Promise<AuditEvent> {
     await ensureMigrated();
     // Single INSERT: event + integrity metadata atomically. A failure here
-    // persists neither, so the chain never has a half-written row. The
-    // UNIQUE index on integrity_sequence enforces no-duplicates even under
-    // concurrent writers (though the chainLock in index.ts already serialises).
-    await pool.query(
-      `INSERT INTO ${prefix}_audit_events (id,agent_id,event_type,outcome,severity,detail,policy_rule_id,organization_id,created_at,integrity_hash,integrity_previous_hash,integrity_sequence,integrity_signed_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
-      [
-        event.id,
-        event.agentId,
-        event.eventType,
-        event.outcome,
-        event.severity,
-        event.detail ? JSON.stringify(event.detail) : null,
-        event.policyRuleId ?? null,
-        event.organizationId ?? null,
-        event.createdAt,
-        integrity.hash,
-        integrity.previousHash,
-        integrity.sequence,
-        integrity.signedAt,
-      ],
-    );
+    // persists neither, so the chain never has a half-written row. Note the
+    // caller pre-computed the sequence from process-local state, so this path
+    // is only safe under a single writer — appendToAuditChain() is the
+    // multi-writer-safe entry point and the one createGovernance() prefers.
+    await pool.query(auditIntegrityInsertSQL(prefix), auditIntegrityInsertParams(event, integrity));
     return event;
   }
 
   async function getChainHead(organizationId?: string): Promise<{ sequence: number; hash: string } | null> {
     await ensureMigrated();
-    // Scope to the org's chain. `IS NOT DISTINCT FROM` matches NULL = NULL so
-    // an undefined org resolves to the org-less chain, not every row.
     const result = await pool.query<{ integrity_sequence: string | number | null; integrity_hash: string | null }>(
-      `SELECT integrity_sequence, integrity_hash FROM ${prefix}_audit_events WHERE integrity_sequence IS NOT NULL AND organization_id IS NOT DISTINCT FROM $1 ORDER BY integrity_sequence DESC LIMIT 1`,
+      chainHeadSQL(prefix),
       [organizationId ?? null],
     );
-    const row = result.rows[0];
-    if (!row || row.integrity_sequence == null || row.integrity_hash == null) return null;
-    // pg returns BIGINT as string by default to preserve precision; coerce.
-    const sequence = typeof row.integrity_sequence === "string"
-      ? parseInt(row.integrity_sequence, 10)
-      : row.integrity_sequence;
-    return { sequence, hash: row.integrity_hash };
+    return parseChainHeadRow(result.rows[0]);
+  }
+
+  async function appendToAuditChain(
+    event: AuditEvent,
+    computeIntegrity: (
+      head: { sequence: number; hash: string } | null,
+    ) => Promise<StoredAuditIntegrity>,
+  ): Promise<{ event: AuditEvent; integrity: StoredAuditIntegrity }> {
+    await ensureMigrated();
+    // Preferred path: a real transaction with a per-org advisory lock makes
+    // head-read → computeIntegrity → INSERT indivisible across ALL writers,
+    // including separate processes sharing this database. The org's chain is
+    // serialised only against itself (hashtext(orgKey)), so unrelated orgs
+    // proceed in parallel.
+    if (typeof pool.connect === "function") {
+      const client = await pool.connect();
+      try {
+        // READ COMMITTED is load-bearing, not cosmetic: the guarantee is that
+        // the head SELECT below — run AFTER the advisory lock is granted — sees
+        // the prior writer's just-committed row. Under READ COMMITTED each
+        // statement takes a fresh snapshot, so it does. Under REPEATABLE READ /
+        // SERIALIZABLE the snapshot is fixed at the first statement (before the
+        // lock is granted), the head read goes stale, and the same sequence is
+        // re-derived → 23505. Pin it so a server/role default can't break us.
+        await client.query("BEGIN ISOLATION LEVEL READ COMMITTED");
+        // pg_advisory_xact_lock auto-releases at COMMIT/ROLLBACK. The org-less
+        // chain uses the empty string, matching the COALESCE(organization_id,'')
+        // partition of the unique index.
+        await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [event.organizationId ?? ""]);
+        const headRes = await client.query<{ integrity_sequence: string | number | null; integrity_hash: string | null }>(
+          chainHeadSQL(prefix),
+          [event.organizationId ?? null],
+        );
+        const head = parseChainHeadRow(headRes.rows[0]);
+        const integrity = await computeIntegrity(head);
+        await client.query(auditIntegrityInsertSQL(prefix), auditIntegrityInsertParams(event, integrity));
+        await client.query("COMMIT");
+        return { event, integrity };
+      } catch (err) {
+        await client.query("ROLLBACK").catch(() => undefined);
+        throw err;
+      } finally {
+        client.release();
+      }
+    }
+
+    // Fallback for pools that expose only query() (no transaction handle):
+    // read the durable head, compute, INSERT — and on a unique-violation
+    // (another writer took the sequence between our read and insert) re-read
+    // the fresh head and retry. Correct without a transaction; bounded retries.
+    const MAX_ATTEMPTS = 8;
+    for (let attempt = 1; ; attempt++) {
+      const head = await getChainHead(event.organizationId);
+      const integrity = await computeIntegrity(head);
+      try {
+        await pool.query(auditIntegrityInsertSQL(prefix), auditIntegrityInsertParams(event, integrity));
+        return { event, integrity };
+      } catch (err) {
+        if (attempt < MAX_ATTEMPTS && isUniqueViolation(err)) continue;
+        throw err;
+      }
+    }
   }
 
   async function getAuditIntegrity(eventId: string): Promise<StoredAuditIntegrity | null> {
@@ -274,11 +327,59 @@ export async function createPostgresStorage(
     queryAuditEvents,
     countAuditEvents,
     createAuditEventWithIntegrity,
+    appendToAuditChain,
     getChainHead,
     getAuditIntegrity,
     migrate,
     close: () => pool.end(),
   };
+}
+
+/** INSERT statement writing an audit event + its integrity columns in one row. */
+function auditIntegrityInsertSQL(prefix: string): string {
+  return `INSERT INTO ${prefix}_audit_events (id,agent_id,event_type,outcome,severity,detail,policy_rule_id,organization_id,created_at,integrity_hash,integrity_previous_hash,integrity_sequence,integrity_signed_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`;
+}
+
+/** Positional params for auditIntegrityInsertSQL, in column order. */
+function auditIntegrityInsertParams(event: AuditEvent, integrity: StoredAuditIntegrity): unknown[] {
+  return [
+    event.id,
+    event.agentId,
+    event.eventType,
+    event.outcome,
+    event.severity,
+    event.detail ? JSON.stringify(event.detail) : null,
+    event.policyRuleId ?? null,
+    event.organizationId ?? null,
+    event.createdAt,
+    integrity.hash,
+    integrity.previousHash,
+    integrity.sequence,
+    integrity.signedAt,
+  ];
+}
+
+/** SELECT for the highest-sequence integrity row of one org's chain. */
+function chainHeadSQL(prefix: string): string {
+  // `IS NOT DISTINCT FROM` matches NULL = NULL so an undefined org resolves to
+  // the org-less chain, not every row.
+  return `SELECT integrity_sequence, integrity_hash FROM ${prefix}_audit_events WHERE integrity_sequence IS NOT NULL AND organization_id IS NOT DISTINCT FROM $1 ORDER BY integrity_sequence DESC LIMIT 1`;
+}
+
+/** Coerce a chain-head row (pg returns BIGINT as string) into typed head or null. */
+function parseChainHeadRow(
+  row: { integrity_sequence: string | number | null; integrity_hash: string | null } | undefined,
+): { sequence: number; hash: string } | null {
+  if (!row || row.integrity_sequence == null || row.integrity_hash == null) return null;
+  const sequence = typeof row.integrity_sequence === "string"
+    ? parseInt(row.integrity_sequence, 10)
+    : row.integrity_sequence;
+  return { sequence, hash: row.integrity_hash };
+}
+
+/** Postgres unique-violation SQLSTATE — the audit chain's per-org sequence index. */
+function isUniqueViolation(err: unknown): boolean {
+  return typeof err === "object" && err !== null && (err as { code?: string }).code === "23505";
 }
 
 function buildAuditWhere(filters: AuditQueryFilters): { clauses: string[]; values: unknown[]; paramIdx: number } {

--- a/packages/governance/src/storage-postgres.ts
+++ b/packages/governance/src/storage-postgres.ts
@@ -283,8 +283,14 @@ export async function createPostgresStorage(
     // Fallback for pools that expose only query() (no transaction handle):
     // read the durable head, compute, INSERT — and on a unique-violation
     // (another writer took the sequence between our read and insert) re-read
-    // the fresh head and retry. Correct without a transaction; bounded retries.
-    const MAX_ATTEMPTS = 8;
+    // the fresh head and retry. Correct without a transaction, and the bound
+    // is a real guarantee, not a hope: every 23505 means a COMPETITOR
+    // committed the sequence we derived, so a writer can lose at most once
+    // per concurrent same-org contender — MAX_ATTEMPTS caps how much
+    // same-instant contention the path absorbs before surfacing the error.
+    // The jittered backoff desynchronises contenders that all read the same
+    // head, so later rounds rarely re-collide.
+    const MAX_ATTEMPTS = 12;
     for (let attempt = 1; ; attempt++) {
       const head = await getChainHead(event.organizationId);
       const integrity = await computeIntegrity(head);
@@ -292,8 +298,8 @@ export async function createPostgresStorage(
         await pool.query(auditIntegrityInsertSQL(prefix), auditIntegrityInsertParams(event, integrity));
         return { event, integrity };
       } catch (err) {
-        if (attempt < MAX_ATTEMPTS && isUniqueViolation(err)) continue;
-        throw err;
+        if (attempt >= MAX_ATTEMPTS || !isUniqueViolation(err)) throw err;
+        await new Promise((resolve) => setTimeout(resolve, Math.random() * Math.min(25 * attempt, 250)));
       }
     }
   }

--- a/packages/governance/src/storage.ts
+++ b/packages/governance/src/storage.ts
@@ -56,6 +56,33 @@ export interface GovernanceStorage {
     hash: string;
   } | null>;
   /**
+   * Atomically append an event to its org's integrity chain, deriving the
+   * sequence and previous-hash from the CURRENT durable head rather than any
+   * caller-held (process-local) state.
+   *
+   * The adapter, holding a per-org lock that spans the whole operation:
+   *   1. reads the current chain head for `event.organizationId`,
+   *   2. calls `computeIntegrity(head)` to derive the HMAC metadata — the
+   *      signing key stays inside the SDK core, never in storage,
+   *   3. persists the event + integrity as one indivisible write.
+   *
+   * `head` is null when the org has no chained events yet. This is the
+   * multi-writer-safe path: concurrent writers — including separate processes
+   * sharing one database — each observe a distinct, monotonic head, so
+   * sequences stay contiguous (no duplicate-key drops) and the hash chain
+   * links to the true latest row instead of a per-process fork.
+   *
+   * Optional: adapters that predate this (0.18.x and earlier) may omit it.
+   * When absent, createGovernance() falls back to createAuditEventWithIntegrity
+   * with a process-local sequence — correct only for single-writer deployments.
+   */
+  appendToAuditChain?(
+    event: AuditEvent,
+    computeIntegrity: (
+      head: { sequence: number; hash: string } | null,
+    ) => Promise<StoredAuditIntegrity>,
+  ): Promise<{ event: AuditEvent; integrity: StoredAuditIntegrity }>;
+  /**
    * Fetch the stored integrity record for a specific event id. Used by
    * integrityChain.export() and verifyAuditIntegrity() to rebuild the chain
    * from durable state instead of in-memory.
@@ -132,6 +159,10 @@ export function createMemoryStorage(): GovernanceStorage {
   const integrity: Map<string, StoredAuditIntegrity> = new Map();
   // Chain head per org (key = organizationId, or "" for the org-less chain).
   const chainHeads: Map<string, { sequence: number; hash: string }> = new Map();
+  // Per-org append lock: serialises head-read → computeIntegrity → write so the
+  // sequence is allocated atomically even when concurrent callers interleave
+  // across the `await` in computeIntegrity.
+  const chainLocks: Map<string, Promise<unknown>> = new Map();
   const orgKeyOf = (organizationId?: string) => organizationId ?? "";
 
   return {
@@ -211,6 +242,25 @@ export function createMemoryStorage(): GovernanceStorage {
     async getChainHead(organizationId?: string) {
       const head = chainHeads.get(orgKeyOf(organizationId));
       return head ? { ...head } : null;
+    },
+    async appendToAuditChain(event, computeIntegrity) {
+      const key = orgKeyOf(event.organizationId);
+      const prev = chainLocks.get(key) ?? Promise.resolve();
+      const run = prev.then(async () => {
+        const head = chainHeads.get(key) ?? null;
+        const integrityMeta = await computeIntegrity(head ? { ...head } : null);
+        events.push(event);
+        if (events.length > MAX_AUDIT_EVENTS) {
+          const dropped = events.splice(0, events.length - MAX_AUDIT_EVENTS);
+          for (const d of dropped) integrity.delete(d.id);
+        }
+        integrity.set(event.id, integrityMeta);
+        chainHeads.set(key, { sequence: integrityMeta.sequence, hash: integrityMeta.hash });
+        return { event, integrity: integrityMeta };
+      });
+      // Lock must advance even if this write throws, or the org's chain wedges.
+      chainLocks.set(key, run.catch(() => undefined));
+      return run;
     },
     async getAuditIntegrity(eventId) {
       const meta = integrity.get(eventId);


### PR DESCRIPTION
## Problem

The tamper-evident integrity audit (`createGovernance({ integrityAudit })`) held the chain's `sequence` and `previousHash` as **process-local** state, resumed from the durable head only **once at boot** (`loadChainHead`, guarded by `state.loaded`), then advanced an in-process counter under an in-process lock.

Under **any multi-process deployment** — Kubernetes replicas, a `pm2` cluster, or serverless instances all writing to one shared database — that assumption breaks:

- **Collision → silent drop.** Two processes derive the same `sequence` for the same org. One `INSERT` wins; the other loses to the `UNIQUE (COALESCE(organization_id,''), integrity_sequence)` index (Postgres `23505`). With the default `onFailure: 'allow'`, that governance decision's tamper-evident record is silently dropped.
- **Fork (even without a collision).** The per-process `previousHash` links to *that process's* last write, not the true durable head, so the hash chain forks across processes and isn't sound under multi-process regardless of collisions.

`storage-postgres.ts` `createAuditEventWithIntegrity()` was a single `INSERT` with the pre-computed sequence — no `ON CONFLICT`, no retry, no head re-read.

## Fix

Sequence allocation and previous-hash derivation are now atomic **against the database, per org**, on every write — never from process-local state.

- **New optional `GovernanceStorage.appendToAuditChain(event, computeIntegrity)`** — the documented storage contract for atomic chain appends. The adapter, under a per-org lock spanning the whole operation, reads the org's durable head, calls `computeIntegrity(head)` (the HMAC signing key stays in the SDK core, never in storage), and persists event + integrity as one indivisible write.
- **Postgres:** `BEGIN ISOLATION LEVEL READ COMMITTED` → `pg_advisory_xact_lock(<classid>, hashtext(org))` → head `SELECT` → `INSERT` → `COMMIT`. The advisory lock (released at `COMMIT`) serialises each org's chain **against itself across all writers, including separate processes**; unrelated orgs proceed in parallel. `READ COMMITTED` is pinned deliberately: it's what guarantees the post-lock head `SELECT` sees the prior writer's just-committed row (a fixed-snapshot isolation level would re-read stale and re-collide). The two-arg lock form namespaces the key under a fixed classid so other advisory-lock users of the same database can't contend. A pool exposing only `query()` (no transaction handle) falls back to a bounded **read-head → insert → retry-on-`23505`** loop with jittered backoff, which is also multi-writer-safe.
- **Memory adapter:** a per-org async lock spanning head-read → compute → write. Correct within a single process; memory is not shared across processes, so it is single-process **by design** (documented).
- **`createGovernance()`** prefers `appendToAuditChain` when present; the previous `createAuditEventWithIntegrity` + process-local sequence path remains only as a **single-writer fallback** for third-party adapters that predate this method.

### Why advisory lock over `ON CONFLICT`-retry
Retry alone doesn't fix the **head-read race** or the **chain fork**: each retry still needs to re-read the durable head and re-hash from it, so a naive retry that reuses process-local `previousHash` produces a forked chain. The advisory lock makes head-read → hash → insert indivisible in one pass. The retry-on-`23505` path is kept only as the fallback for pools without `connect()` — there it *does* re-read the head each attempt, so it's correct; the bound is deterministic, not probabilistic (every `23505` means a competitor committed the derived sequence, so a writer loses at most once per concurrent same-org contender).

### Verification order = sequence, not wall clock
`createdAt` is stamped before the append lock allocates the sequence, so under concurrent writers a lower sequence can carry a later timestamp (lock-wait inversion, cross-process clock skew). `verifyAuditIntegrity()` and `integrityChain.export()` now order by the HMAC-covered `sequence` (`createdAt` only tiebreaks legacy forked rows) — the old `createdAt`-first sort could report a valid multi-writer chain as tampered. Tamper-safe: the sequence is inside the signed hash, so forging it still fails the hash / previous-hash checks.

### API surface unchanged
Existing consumers need no code change beyond upgrading — `createGovernance({ integrityAudit })` picks up the safe path automatically once its storage adapter (a real `pg.Pool`) exposes `connect()`. Canonical hash form, per-org scoping, `verify()`, `export()`, and `stats()` behaviour are unchanged.

One behavioural note for reviewers: the transactional path now holds a pooled connection across `BEGIN → lock-wait → SELECT → hash → INSERT → COMMIT` (the old path was grab/insert/release per statement). A same-instant burst across many orgs would queue on the pool and degrade to `connectionTimeout` / `statement_timeout` → the same `onAuditError` path (not a silent drop).

## Multi-process guidance + docs (this PR)

The fix is generalised for the SDK's whole audience, not only the deployment that surfaced it:

- **README** gains a "Multi-process deployments" section: what `appendToAuditChain` guarantees, a per-adapter support table (Postgres / memory / third-party fallback), and how a **custom** storage adapter should implement atomic append (row lock, advisory lock, serializable txn, or CAS-retry on its uniqueness constraint).
- The standalone **`createIntegrityAudit()`** wrapper (`audit-integrity.ts`) is the *other* entry point that keeps its chain in process memory — the same unsoundness class on a separate surface. It holds no storage handle to append against, so it cannot reuse the contract; it is now documented as **single-process only** (prominent JSDoc + README + a regression test asserting a second wrapper starts its own sequence at 1 rather than resuming the durable head), with consumers pointed at `createGovernance({ integrityAudit })` for durable multi-process audit.
- `integrityChain.stats()` still reports this process's last-written sequence/hash (a process-local cache); `export()` + `verifyAuditIntegrity()` are the authoritative durable readers. A DB-backed `stats()` is **deferred** — it would turn a sync method async (a breaking signature change) — and noted in the CHANGELOG.

## Tests

`npm test` — **1448 pass**, `tsc --noEmit` clean.

- **`audit-chain-multiwriter.test.ts`** — the load-bearing regression test: **two `createGovernance` instances sharing one storage** (two-writer model) fire N concurrent interleaved writes → exactly N rows, **contiguous 1..N sequences** (no duplicates/gaps), and the interleaved chain **verifies standalone**. Also covers two writers × two orgs, and a timestamp-inverted-vs-sequence chain (fails on the old `createdAt` sort).
- **`audit-chain-append-postgres.test.ts`** — asserts the Postgres SQL **shape** (`BEGIN ISOLATION` → advisory-lock → head `SELECT` → `INSERT` → `COMMIT`), DB-head-derived sequencing across sequential appends, an orchestration run of two instances over one pool, retry-fallback recovery from a `23505`, and dead-connection release on `ROLLBACK` failure.
- **`audit-integrity.test.ts`** — new: documents the `createIntegrityAudit()` single-process boundary.

### Verified against a real Postgres (not just the mock)
The committed pg test models `pg_advisory_xact_lock` as an in-process mutex (the repo harness has no Postgres), so it validates orchestration + SQL shape but can't prove real cross-connection locking. The two-writer scenario was additionally run out-of-band against an **ephemeral real Postgres 14** with **two independent `pg.Pool`s** (real `connect()`, real advisory lock, real unique index), 60 concurrent writes to one org:

| Path | Attempted | Persisted | Dropped (`23505`) | Chain |
| --- | --- | --- | --- | --- |
| **Before this PR** (legacy path) | 60 | **30** | **30** | forked |
| **After this PR** | 60 | **60** | **0** | contiguous 1..60, valid |

The "before" row reproduces the failure mode; the "after" row demonstrates the fix on real cross-connection locks. (Throwaway harness — not committed.)

## Rollout note

The advisory lock only protects writers that take it. During a mixed-version rolling deploy, pre-`0.18.2` processes still allocate from their process-local counters and can collide with or fork past locked writers. Replace all writers together; expect residual `23505` warnings until the last old process drains.

## Compatibility

Backward compatible. `appendToAuditChain` is an **optional** interface method — adapters that omit it fall back to the existing single-writer path. Canonical hash form and per-org scoping are unchanged, so existing chains keep verifying. Versioned as a patch (`0.18.2`) per the repo's convention (fix + optional interface addition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes audit integrity under concurrent production writers (silent event loss / chain fork before); rolling deploys need all writers on 0.18.2+ or collisions can persist during mixed versions.
> 
> **Overview**
> **Release 0.18.2** fixes tamper-evident audit (`integrityAudit`) when several processes share one store: process-local sequence/`previousHash` used to collide on the per-org unique index (silent drops) and fork the HMAC chain.
> 
> **New storage contract `appendToAuditChain`** — adapters read the durable head under a per-org lock, call back into the SDK for HMAC metadata, and insert atomically. **`createGovernance()`** uses it when present; legacy `createAuditEventWithIntegrity` + in-process counters remain for single-writer adapters, with a **one-time `onAuditError` warning** if durable integrity exists without atomic append.
> 
> **Postgres** implements transactional append (`READ COMMITTED`, `pg_advisory_xact_lock`, head `SELECT` scoped with `COALESCE(organization_id,'')`) plus a **query-only pool fallback** (bounded `23505` retries). **Memory** gets per-org async locks. **Export/verify** now sort by **integrity `sequence`** (not `createdAt` first), read integrity whenever `getAuditIntegrity` exists, and document that **`createIntegrityAudit()`** stays in-process only.
> 
> README adds a **Multi-process deployments** section; extensive regression tests cover multi-writer chains, partial adapters, and Postgres orchestration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fadddbd616755daee4708b1985cbf98e98cab59f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->