### PR TITLE
feat: DB-backed integrity chain stats (multi-process truth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,18 @@ transaction, or a compare-and-set retry on your uniqueness constraint). If you
 can't, leave it unimplemented and run a single writer — the SDK falls back
 safely and warns.
 
+**`integrityChain.stats()` reads the durable head (async since 0.19).** It
+resolves the latest sequence + hash from `storage.getChainHead()` on every
+call — so under multiple writers it reports the true tip, including writes made
+by other processes, not just this process's last append. `export()` and
+`verifyAuditIntegrity()` are already durable-backed; as of 0.19 `stats()` joins
+them and is `async` (was sync ≤0.18) — `await` it. Adapters with no
+`getChainHead` fall back to the process-local cache (single-process only).
+
+```typescript
+const { latestSequence, latestHash } = await gov.integrityChain!.stats('org_acme');
+```
+
 **The standalone `createIntegrityAudit()` wrapper is single-process only.** It
 keeps its chain in process memory and never persists integrity metadata, so it
 forks across processes and loses verifiability across restarts. Use it for

--- a/packages/governance/CHANGELOG.md
+++ b/packages/governance/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [0.19.0] - 2026-07-20 — DB-backed integrity chain stats (multi-process truth)
+
+Completes the multi-process hardening from 0.18.2. That release made the audit
+integrity chain's *writes* atomic against the durable per-org head and made
+`export()` / `verifyAuditIntegrity()` read durable state. `integrityChain.stats()`
+was the one reader left on process-local state — it returned this process's
+last-written `sequence` / `lastHash` from an in-closure cache, so under a
+multi-process deployment (replicas, `pm2` cluster, serverless) it lagged writes
+made by other processes sharing the store. This release makes `stats()` read the
+durable head too, so all three readers agree on the true tip.
+
+### Changed — `integrityChain.stats()` is DB-backed and now async (BREAKING-ISH)
+
+- `stats(organizationId?)` reads `storage.getChainHead(organizationId)` fresh on
+  every call whenever the adapter provides it (the memory and Postgres adapters
+  do), returning the true durable `latestSequence` / `latestHash` — including
+  writes from other processes — instead of a process-local cache. It does not
+  mutate chain state; the write path still owns the per-org head under its lock.
+- Because the durable read is a storage round-trip, the method is now `async`:
+  it returns `Promise<{ latestSequence; latestHash; algorithm }>` (was a plain
+  object ≤0.18.x). Callers must `await` it. This is the same sync→durable shift
+  0.12.0 made for the chain itself; the return shape is otherwise unchanged (no
+  new fields).
+- Adapters with no `getChainHead` (pre-0.12 / custom) fall back to this
+  process's boot-resumed local cache — correct single-process only, matching the
+  fallback the write path already uses.
+- Pre-1.0 minor bump per 0.x semver. All in-repo callers are updated; external
+  callers add one `await`.
+
+### Notes
+
+- The standalone `createIntegrityAudit()` wrapper in `audit-integrity.ts` is
+  unchanged and remains **single-process only** — it holds no storage handle to
+  read a durable head, and its `stats()` was already `async`.
+- Supersedes the 0.18.2 "`stats()` … deferred (it would change the method from
+  sync to async)" note — that is now done and tracked here.
+
 ## [0.18.2] - 2026-07-15 — Multi-process-safe audit integrity chain
 
 Fixes silent audit-event loss and hash-chain forking when the integrity audit

--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -500,6 +500,18 @@ transaction, or a compare-and-set retry on your uniqueness constraint). If you
 can't, leave it unimplemented and run a single writer — the SDK falls back
 safely and warns.
 
+**`integrityChain.stats()` reads the durable head (async since 0.19).** It
+resolves the latest sequence + hash from `storage.getChainHead()` on every
+call — so under multiple writers it reports the true tip, including writes made
+by other processes, not just this process's last append. `export()` and
+`verifyAuditIntegrity()` are already durable-backed; as of 0.19 `stats()` joins
+them and is `async` (was sync ≤0.18) — `await` it. Adapters with no
+`getChainHead` fall back to the process-local cache (single-process only).
+
+```typescript
+const { latestSequence, latestHash } = await gov.integrityChain!.stats('org_acme');
+```
+
 **The standalone `createIntegrityAudit()` wrapper is single-process only.** It
 keeps its chain in process memory and never persists integrity metadata, so it
 forks across processes and loses verifiability across restarts. Use it for

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "governance-sdk",
-  "version": "0.18.2",
+  "version": "0.19.0",
   "description": "AI Agent Governance for TypeScript — policy enforcement, scoring, compliance, and audit for AI agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/governance/src/audit-chain-append-postgres.test.ts
+++ b/packages/governance/src/audit-chain-append-postgres.test.ts
@@ -198,6 +198,15 @@ describe("postgres appendToAuditChain — transactional path", () => {
     assert.deepEqual(sequences, Array.from({ length: N }, (_, i) => i + 1));
     const result = await verifyAuditIntegrity(chain, KEY);
     assert.equal(result.valid, true, result.breakDetail ?? "invalid");
+
+    // stats() reads the durable head from the shared pool, so BOTH pods report
+    // the true tip (N) — not their own process-local last append.
+    const statsA = await podA.integrityChain!.stats("orgP");
+    const statsB = await podB.integrityChain!.stats("orgP");
+    assert.equal(statsA.latestSequence, N, "podA stats reflects the durable DB head");
+    assert.equal(statsB.latestSequence, N, "podB stats reflects the durable DB head");
+    assert.equal(statsA.latestHash, chain[N - 1].integrity.hash, "latestHash is the DB tip");
+    assert.equal(statsA.latestHash, statsB.latestHash, "both pods agree via the shared DB head");
   });
 });
 

--- a/packages/governance/src/audit-chain-e2e.test.ts
+++ b/packages/governance/src/audit-chain-e2e.test.ts
@@ -205,7 +205,7 @@ describe("integrity chain end-to-end — every SDK audit write is HMAC-chained",
     await gov.register({ name: "a", framework: "mastra", owner: "t" });
     await gov.register({ name: "b", framework: "mastra", owner: "t" });
 
-    const stats = gov.integrityChain!.stats();
+    const stats = await gov.integrityChain!.stats();
     assert.equal(stats.latestSequence, 2);
     assert.equal(stats.algorithm, "hmac-sha256");
     assert.match(stats.latestHash, /^[0-9a-f]{64}$/);

--- a/packages/governance/src/audit-chain-multiwriter.test.ts
+++ b/packages/governance/src/audit-chain-multiwriter.test.ts
@@ -51,6 +51,16 @@ describe("integrity chain — multi-writer (shared storage, two instances)", () 
     // The single interleaved chain verifies standalone.
     const result = await verifyAuditIntegrity(chain, KEY);
     assert.equal(result.valid, true, result.breakDetail ?? "chain did not verify");
+
+    // stats() reflects the TRUE durable head (N), not either pod's
+    // process-local last-append sequence. Under interleaving each pod's own
+    // cache lands below N, so a process-local stats() would under-report here.
+    const statsA = await podA.integrityChain!.stats("orgX");
+    const statsB = await podB.integrityChain!.stats("orgX");
+    assert.equal(statsA.latestSequence, N, "podA stats must see the union head, not its own writes");
+    assert.equal(statsB.latestSequence, N, "podB stats must see the union head, not its own writes");
+    assert.equal(statsA.latestHash, chain[N - 1].integrity.hash, "latestHash is the true tip");
+    assert.equal(statsA.latestHash, statsB.latestHash, "both pods agree on the durable head");
   });
 
   it("keeps each org's chain contiguous when two pods write to two orgs at once", async () => {

--- a/packages/governance/src/audit-chain-partial-adapter.test.ts
+++ b/packages/governance/src/audit-chain-partial-adapter.test.ts
@@ -113,4 +113,24 @@ describe("integrity chain — partial storage adapters", () => {
     const verification = await verifyAuditIntegrity(chain, KEY);
     assert.equal(verification.valid, true, verification.breakDetail ?? "chain should verify");
   });
+
+  it("stats() falls back to the process-local cache when the adapter has no getChainHead", async () => {
+    const base = createMemoryStorage();
+    // Durable writes but NO durable-head reader — the only stats() input left
+    // is this process's boot-resumed cache (correct single-process only).
+    const noHead: GovernanceStorage = {
+      ...coreSurface(base),
+      createAuditEventWithIntegrity: base.createAuditEventWithIntegrity,
+      getAuditIntegrity: base.getAuditIntegrity,
+      // intentionally omit: getChainHead, appendToAuditChain
+    };
+
+    const gov = createGovernance({ storage: noHead, integrityAudit: { signingKey: KEY } });
+    await writeN(gov, 3);
+
+    const stats = await gov.integrityChain!.stats();
+    assert.equal(stats.latestSequence, 3, "stats tracks this process's local sequence");
+    assert.match(stats.latestHash, /^[0-9a-f]{64}$/, "latestHash is the local chain tip");
+    assert.equal(stats.algorithm, "hmac-sha256");
+  });
 });

--- a/packages/governance/src/audit-chain-per-org.test.ts
+++ b/packages/governance/src/audit-chain-per-org.test.ts
@@ -47,8 +47,8 @@ describe("integrity chain — per-org scoping", () => {
     assert.equal(rB.valid, true, rB.breakDetail ?? "");
 
     // Heads are tracked per-org.
-    assert.equal(gov.integrityChain!.stats("orgA").latestSequence, 3);
-    assert.equal(gov.integrityChain!.stats("orgB").latestSequence, 2);
+    assert.equal((await gov.integrityChain!.stats("orgA")).latestSequence, 3);
+    assert.equal((await gov.integrityChain!.stats("orgB")).latestSequence, 2);
   });
 
   it("binds organizationId into the hash — relabelling into another org breaks verification", async () => {
@@ -72,7 +72,7 @@ describe("integrity chain — per-org scoping", () => {
     const chain = await gov.integrityChain!.export({ organizationId: "orgMeta" });
     assert.equal(chain.length, 1);
     assert.equal(chain[0].organizationId, "orgMeta");
-    assert.equal(gov.integrityChain!.stats("orgMeta").latestSequence, 1);
+    assert.equal((await gov.integrityChain!.stats("orgMeta")).latestSequence, 1);
   });
 
   it("keeps the org-less chain independent from org chains", async () => {
@@ -85,8 +85,8 @@ describe("integrity chain — per-org scoping", () => {
     const orgless = await gov.integrityChain!.export({});
     const orglessOnly = orgless.filter((e) => e.organizationId == null);
     assert.deepEqual(orglessOnly.map((e) => e.integrity.sequence), [1, 2]);
-    assert.equal(gov.integrityChain!.stats().latestSequence, 2);
-    assert.equal(gov.integrityChain!.stats("orgA").latestSequence, 1);
+    assert.equal((await gov.integrityChain!.stats()).latestSequence, 2);
+    assert.equal((await gov.integrityChain!.stats("orgA")).latestSequence, 1);
   });
 
   it("register() stamps the org onto the agent record and the agent_registered event", async () => {

--- a/packages/governance/src/audit-chain-restart.test.ts
+++ b/packages/governance/src/audit-chain-restart.test.ts
@@ -34,7 +34,7 @@ describe("integrity chain restart durability (0.12)", () => {
 
     const gov1 = createGovernance({ storage, integrityAudit: { signingKey: KEY } });
     await writeSomeEvents(gov1, 5);
-    const stats1 = gov1.integrityChain!.stats();
+    const stats1 = await gov1.integrityChain!.stats();
     assert.equal(stats1.latestSequence, 5, "first instance wrote sequences 1..5");
     const firstHash = stats1.latestHash;
 
@@ -42,7 +42,7 @@ describe("integrity chain restart durability (0.12)", () => {
     const gov2 = createGovernance({ storage, integrityAudit: { signingKey: KEY } });
     // Write one more event — must pick up at sequence 6 and chain to firstHash.
     await writeSomeEvents(gov2, 1);
-    const stats2 = gov2.integrityChain!.stats();
+    const stats2 = await gov2.integrityChain!.stats();
     assert.equal(stats2.latestSequence, 6, "second instance resumed at sequence 6");
     assert.notEqual(stats2.latestHash, firstHash, "new event produced new head");
 

--- a/packages/governance/src/index.ts
+++ b/packages/governance/src/index.ts
@@ -201,8 +201,18 @@ export interface GovernanceInstance {
     /**
      * Chain stats for one org (or the org-less chain when omitted):
      * latest sequence, latest hash, algorithm.
+     *
+     * Reads the **durable** chain head from storage (`getChainHead`) whenever
+     * the adapter provides it — the memory and Postgres adapters do — so under
+     * a multi-process deployment the stats reflect the true head, including
+     * writes made by other processes sharing the store, not just this
+     * process's last append. Adapters with no `getChainHead` fall back to this
+     * process's boot-resumed local cache (correct single-process only).
+     *
+     * Async since 0.19.0 (was sync ≤0.18.x): the durable head read is a
+     * storage round-trip. `await` the call.
      */
-    stats: (organizationId?: string) => { latestSequence: number; latestHash: string; algorithm: string };
+    stats: (organizationId?: string) => Promise<{ latestSequence: number; latestHash: string; algorithm: string }>;
   };
   audit: {
     log: (event: Omit<AuditEvent, "id" | "createdAt">) => Promise<AuditEvent>;
@@ -787,8 +797,26 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
             return a.createdAt.localeCompare(b.createdAt);
           });
         },
-        stats(organizationId?: string) {
+        async stats(organizationId?: string) {
+          // Durable head is the source of truth. Reading it FRESH per call
+          // (not the process-local cache, which only reflects this process's
+          // own appends) is what makes stats() correct under multiple writers
+          // sharing one store — same durable-head machinery export() uses.
+          // No mutation of chain state here: the write path owns
+          // orgState.lastHash/sequence under the per-org lock.
+          if (typeof storage.getChainHead === "function") {
+            const head = await storage.getChainHead(organizationId);
+            return {
+              latestSequence: head?.sequence ?? 0,
+              latestHash: head?.hash ?? GENESIS_HASH,
+              algorithm: "hmac-sha256",
+            };
+          }
+          // Adapter without a durable head (pre-0.12 / custom): fall back to
+          // this process's cache, resuming once from boot state if needed.
+          // Session-local by construction — correct single-process only.
           const orgState = chainStateFor(organizationId);
+          if (!orgState.loaded) await loadChainHead(orgState, organizationId);
           return {
             latestSequence: orgState.sequence,
             latestHash: orgState.lastHash,


### PR DESCRIPTION
## Problem (issue #39)

After #35 (0.18.2) made the audit integrity chain's **writes** atomic against the durable per-org head and made `export()` / `verifyAuditIntegrity()` read durable state, `integrityChain.stats()` was the **only remaining reader on process-local state**. It returned this process's last-written `sequence` / `lastHash` from an in-closure cache, so under a multi-process deployment (replicas, `pm2` cluster, serverless sharing one Postgres DB) it lagged writes made by other processes — the last process-local sequence/hash instead of the true DB head.

Deferred from #35 because the fix changes the signature from **sync → async** (the durable read is a storage round-trip).

## Fix

`stats(organizationId?)` now reads `storage.getChainHead(organizationId)` **fresh on every call** whenever the adapter provides it (the memory and Postgres adapters do), returning the true durable `latestSequence` / `latestHash` — including writes from other processes. It reuses #35's exact durable-head machinery (`getChainHead`, the same reader `export()` resumes from); no parallel path. It does **not** mutate chain state — the write path still owns `orgState.lastHash`/`sequence` under the per-org lock. Adapters with no `getChainHead` (pre-0.12 / custom) fall back to the process-local cache (correct single-process only), matching the fallback the write path already uses.

## API decision + rationale

**Option 1 — make `stats()` async, minor bump to `0.19.0`, labeled BREAKING-ISH.** Chosen over adding a parallel `statsAsync()`/`getChainStats()` and leaving `stats()` sync-but-wrong.

Rationale, as the repo's own conventions dictate:
- **Direct precedent.** 0.12.0 (`### Changed — integrity audit chain is now durable (BREAKING-ISH)`) made *this same chain* durable via a sync→durable shift at a **minor** bump with a `BREAKING-ISH` marker. This PR is the identical move for the last reader; it mirrors that entry.
- **#35's design language.** Durable state is the source of truth; every other chain reader (`export()`, `verifyAuditIntegrity()`) is already `async` and reads from storage. Making `stats()` async **unifies** it with them rather than bolting on a permanent parallel method.
- **Pre-1.0 semver.** 0.x explicitly permits breaking changes in a minor bump; the repo already ships breaking changes at minor bumps (0.10.0/0.11.0 `Removed (BREAKING)`, 0.16.0 signature change).
- **No permanent cruft.** Option 2 would leave a deprecated `stats()` returning **wrong** data in multi-process forever — the exact footgun this issue exists to kill.
- **Small blast radius.** The method is ~5 days old (0.18.0) and all callers are internal; external callers add one `await`.

Return shape is otherwise unchanged (no new fields — `getChainHead` returns no count, and the instance `stats()` never exposed `totalEvents`).

## Sweep — other process-local readers?

Re-verified against current `main`: `stats()` is the **only** process-local reader on the durable path.
- `integrityChain.export()` — already durable-backed (`loadChainHead` + `storage.queryAuditEvents`/`getAuditIntegrity`), orders by signed sequence. Not affected.
- The instance `integrityChain` has no `verify()` — verification is the standalone `verifyAuditIntegrity(chain, key)` over an exported (durable) chain.
- The standalone `createIntegrityAudit()` wrapper (`stats`/`verify`/`export` over an in-memory `integrityMap`) is the **documented single-process construct** — it holds no storage handle to append/read a durable head. Left untouched by design; its `stats()` was already async.

## Tests (full suite green: 1451 pass / 0 fail; `tsc --noEmit` clean)

- **Multi-process discriminating test** (`audit-chain-multiwriter.test.ts`): 40 interleaved writes across podA/podB over one shared store → `await podA.stats("orgX")` and `podB.stats("orgX")` both report `latestSequence === 40` and agree on `latestHash` (the true tip). Fails against old process-local behavior (each pod's own cache lands below 40 under interleaving), passes against the fix.
- **Postgres path** (`audit-chain-append-postgres.test.ts`): reuses #35's transactional mock pool — after 30 interleaved cross-pod writes, both pods' `stats()` read the durable DB head.
- **Fallback path** (`audit-chain-partial-adapter.test.ts`): adapter with durable writes but **no** `getChainHead` → `stats()` returns the process-local cache (`latestSequence === 3`), preserving single-process semantics.
- **Memory single-process semantics preserved**: existing per-org (`stats("orgA") === 3` etc.) and restart-durability (`stats()` resumes at 6 across a fresh instance) tests updated to `await`, still green.

## Docs

- README "Multi-process deployments" gains a `stats()`-is-DB-backed-and-async note (root + synced package copy).
- CHANGELOG `[0.19.0]` entry, BREAKING-ISH marker, supersedes the 0.18.2 deferred note.
- `package.json` → 0.19.0. JSDoc on the changed method.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking sync→async on `integrityChain.stats()` requires external callers to `await`; behavior change affects audit monitoring in multi-process Postgres deployments but does not alter the write path or chain verification.
> 
> **Overview**
> **0.19.0** finishes multi-process integrity audit hardening: `integrityChain.stats()` was the last reader still using process-local sequence/hash, so replicas could under-report the chain tip after writes from other pods.
> 
> **`stats(organizationId?)` is now async** and, when the storage adapter implements `getChainHead`, loads the durable head on every call (same machinery as `export()`). Return shape is unchanged; callers add `await`. Adapters without `getChainHead` still use the boot-resumed process-local cache (single-writer only).
> 
> README multi-process section, CHANGELOG **BREAKING-ISH** entry, public types/JSDoc, and in-repo tests (multi-writer, Postgres mock, partial-adapter fallback) are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c2153a85c269b0a65b5252610169bc801009c02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->