### PR TITLE
security: consolidated high remediation

### DIFF
--- a/examples/demo-app/package-lock.json
+++ b/examples/demo-app/package-lock.json
@@ -792,9 +792,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -812,9 +809,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -832,9 +826,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -852,9 +843,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -872,9 +860,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -892,9 +877,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1280,9 +1262,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1481,9 +1463,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2125,10 +2107,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/examples/demo-app/package.json
+++ b/examples/demo-app/package.json
@@ -27,5 +27,10 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^8.1.0"
+  },
+  "overrides": {
+    "js-yaml@4": "4.3.0",
+    "brace-expansion@1": "1.1.16",
+    "brace-expansion@5": "5.0.7"
   }
 }


### PR DESCRIPTION
Consolidated remediation of all within-major, bump-fixable **HIGH** Dependabot alerts in `examples/demo-app` (Lua-owned `governance` repo). No criticals were open.

## Highs closed (3)
| Alert | Package | From → To | Advisory |
|---|---|---|---|
| #22 | js-yaml | 4.1.1 → 4.3.0 | GHSA-52cp-r559-cp3m |
| #21 | brace-expansion | 1.1.14 → 1.1.16 | GHSA-3jxr-9vmj-r5cp |
| #20 | brace-expansion | 5.0.5 → 5.0.7 | GHSA-3jxr-9vmj-r5cp |

Also incidentally clears MEDIUM #19 (js-yaml GHSA-h67p-54hq-rp68) via the same 4.3.0 bump.

## Approach
All three are transitive deps. Pinned with **major-scoped npm overrides** (`js-yaml@4`, `brace-expansion@1`, `brace-expansion@5`) so the two distinct brace-expansion majors (1.x under the top level, 5.x under `@typescript-eslint/typescript-estree`) are each fixed *within* their own major line — no cross-major downgrade regression. Lockfile regenerated; `npm ci` verified locally (installs 4.3.0 / 1.1.16 / 5.0.7).

## Out of scope
- LOW #17 `@babel/core` <=7.29.0 (below HIGH threshold) — left as-is.
- No major-only fixes required in this repo.

Signed commit via createCommitOnBranch. Do not merge yet — left open, green, and ready for review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only changes in an example app with patch/minor bumps within existing majors; no runtime or auth logic touched.
> 
> **Overview**
> Addresses **HIGH** Dependabot alerts in `examples/demo-app` by pinning transitive dependency versions with **major-scoped npm `overrides`**: `js-yaml@4` → 4.3.0, `brace-expansion@1` → 1.1.16, and `brace-expansion@5` → 5.0.7 (separate majors so eslint’s tree isn’t forced onto the wrong line).
> 
> The lockfile is regenerated to reflect those pins; incidental lockfile churn (e.g. removed `libc` fields on some `@rolldown` optional bindings) comes from the refresh, not app logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1157483fc5d99bfed5e75bf1f576fed54a292e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->