### PR TITLE
security: new-advisory remediation

### DIFF
--- a/examples/demo-app/package-lock.json
+++ b/examples/demo-app/package-lock.json
@@ -2515,9 +2515,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2654,9 +2654,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -2674,7 +2674,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/examples/demo-app/package.json
+++ b/examples/demo-app/package.json
@@ -31,6 +31,7 @@
   "overrides": {
     "js-yaml@4": "4.3.0",
     "brace-expansion@1": "1.1.16",
-    "brace-expansion@5": "5.0.7"
+    "brace-expansion@5": "5.0.7",
+    "postcss@8": "^8.5.18"
   }
 }


### PR DESCRIPTION
## Summary
Remediates the newly-created **OPEN** Dependabot alert in this repo (any severity, within-major bump-fixable only).

### Fixed
- **postcss** (alert #23, high, created 2026-07-25): `8.5.15 -> 8.5.23` via `overrides` in `examples/demo-app/package.json` (within-major 8.x; first patched 8.5.18). Transitive dev dependency (pulled by vite). Lockfile regenerated; also carries transitive `nanoid 3.3.15 -> 3.3.16`.

### Deferred (needs-major, not touched)
None open. No needs-major advisories are currently OPEN in this repo.

### Notes
- brace-expansion alert #24 (<=5.0.7) is **auto_dismissed** by Dependabot — not open — so it is intentionally left untouched.
- No major bumps. No forced upgrades. Root workspaces (`packages/*`) are unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only dependency bump in the example app with no runtime or monorepo workspace impact.
> 
> **Overview**
> Addresses a **high** Dependabot alert on transitive **postcss** in `examples/demo-app` by adding an npm **`overrides`** entry (`postcss@8`: `^8.5.18`), which resolves the lockfile to **8.5.23** (from 8.5.15). Postcss is pulled in as a **dev** dependency through **Vite**; no application or workspace package code changes.
> 
> The regenerated lockfile also bumps **nanoid** **3.3.15 → 3.3.16** as a postcss dependency. Root `packages/*` workspaces are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 832c85cc6a69f65868e68bd38372857e074fa55e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->