### PR TITLE
chore(ci): pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
       matrix:
         node-version: [20, 22, 24]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
## What
Automated **supply-chain hardening**: repins every GitHub-Action `uses:` (workflows + composite actions) from a mutable tag/branch to the **full 40-char commit SHA** it resolves to right now, keeping the tag as a `# <tag>` comment.

Pinned **4** reference(s).

## Why
A `@v4` tag is mutable — whoever controls it can repoint it at different code that then runs in CI with our secrets (OWASP **CICD-SEC-4**). A SHA is immutable. Prerequisite for the org-wide *'require actions pinned to a full-length commit SHA'* policy.

## Safety
- **Zero behaviour change** — each SHA is the exact commit the tag points at today.
- Dependabot/Renovate still work via the `# <tag>` comment.
- Mechanical diff — only `uses:` lines changed.

Generated with Claude Code