### PR TITLE
feat(policy): requireToolApproval preset for tool-name approval gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,8 @@ Define rules that govern agent behavior at runtime. Policies return one of **fiv
 
 - `blockTools(toolNames)` — block specific tools from being called
 - `allowOnlyTools(toolNames)` — whitelist-only tool access
-- `requireApproval(condition)` — gate actions behind human approval
+- `requireApproval(actionTypes)` — gate action *categories* (`ctx.action`) behind human approval
+- `requireToolApproval(toolNames)` — gate specific tools by name (`ctx.tool`) behind human approval
 - `tokenBudget(limit)` — enforce token consumption limits
 - `rateLimit(config)` — throttle agent requests. **Stateless** — the rule
   reads `ctx.recentActionCount`, which your host populates. Durable

--- a/packages/governance/CHANGELOG.md
+++ b/packages/governance/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.20.0] - 2026-08-08 — Tool-name approval gating (`requireToolApproval`)
+
+Adds a first-class way to require human approval for specific *tools*. The
+existing `requireApproval(actions)` preset compiles an `action_type` condition,
+which matches the action *category* (`ctx.action`). Hosts that evaluate every
+tool invocation as `action: "tool_call"` with the tool name in `ctx.tool`
+could not express "require approval for tool X" — a tool-name list fed into
+`requireApproval()` produced a rule that never matched at runtime.
+
+### Added
+
+- `tool_match` built-in condition — outcome-neutral membership test on
+  `ctx.tool` (the same matching `tool_blocked` uses, without the block-list
+  framing). Stage default: `process`.
+- `requireToolApproval(tools, reason?)` preset — builds a
+  `tool_match` rule with outcome `require_approval`, priority 80. Exported
+  from the package root and `governance-sdk/policy` alongside the other
+  presets.
+
+### Notes
+
+- `requireApproval(actions)` is unchanged — it remains the correct preset for
+  genuine action categories (`"payment"`, `"database_mutation"`, …). A
+  `tool_call` whose tool name coincides with an action-type string still does
+  not match `action_type` rules.
+
 ## [0.19.0] - 2026-07-20 — DB-backed integrity chain stats (multi-process truth)
 
 Completes the multi-process hardening from 0.18.2. That release made the audit

--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -263,7 +263,8 @@ Define rules that govern agent behavior at runtime. Policies return one of **fiv
 
 - `blockTools(toolNames)` — block specific tools from being called
 - `allowOnlyTools(toolNames)` — whitelist-only tool access
-- `requireApproval(condition)` — gate actions behind human approval
+- `requireApproval(actionTypes)` — gate action *categories* (`ctx.action`) behind human approval
+- `requireToolApproval(toolNames)` — gate specific tools by name (`ctx.tool`) behind human approval
 - `tokenBudget(limit)` — enforce token consumption limits
 - `rateLimit(config)` — throttle agent requests. **Stateless** — the rule
   reads `ctx.recentActionCount`, which your host populates. Durable

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "governance-sdk",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "AI Agent Governance for TypeScript — policy enforcement, scoring, compliance, and audit for AI agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/governance/src/conditions/builtins.ts
+++ b/packages/governance/src/conditions/builtins.ts
@@ -53,6 +53,14 @@ export function getBuiltinConditions(
       },
     },
     {
+      name: "tool_match",
+      description: "Match specific tools by name (outcome-neutral membership test on ctx.tool)",
+      evaluator: (ctx, p) => {
+        const tools = p.tools as string[];
+        return !!ctx.tool && tools.includes(ctx.tool);
+      },
+    },
+    {
       name: "action_type",
       description: "Gate specific action types",
       evaluator: (ctx, p) => {

--- a/packages/governance/src/index.ts
+++ b/packages/governance/src/index.ts
@@ -871,7 +871,7 @@ export function createGovernance(config: GovernanceConfig = {}): GovernanceInsta
 
 export { storedToRegistration };
 export { assessAgent, assessFleet, getGovernanceLevel } from "./scorer.js";
-export { createPolicyEngine, blockTools, allowOnlyTools, requireApproval, tokenBudget, rateLimit, requireLevel, requireSignedIdentity, requireSequence, timeWindow } from "./policy.js";
+export { createPolicyEngine, blockTools, allowOnlyTools, requireApproval, requireToolApproval, tokenBudget, rateLimit, requireLevel, requireSignedIdentity, requireSequence, timeWindow } from "./policy.js";
 export type { PolicyRule, PolicyEngine, PolicyAction, PolicyCondition, PolicyOutcome, PolicyStage, EnforcementContext, EnforcementDecision, PolicyEngineConfig, ConditionEvaluator, RegisteredConditionType } from "./policy.js";
 export type { AgentRegistration, AgentFramework, AgentStatus, GovernanceAssessment, GovernanceLevel, DimensionResult, ScoreDimension, FleetSummary } from "./types.js";
 export { detectInjection, createInjectionGuard, getBuiltinPatterns } from "./injection-detect.js";

--- a/packages/governance/src/policy-presets.test.ts
+++ b/packages/governance/src/policy-presets.test.ts
@@ -4,12 +4,15 @@ import {
   blockTools,
   allowOnlyTools,
   requireApproval,
+  requireToolApproval,
   tokenBudget,
   rateLimit,
   requireLevel,
   requireSequence,
   timeWindow,
 } from "./policy-presets";
+import { createPolicyEngine } from "./policy";
+import type { EnforcementContext } from "./policy";
 
 describe("policy preset builders", () => {
   describe("blockTools", () => {
@@ -94,6 +97,77 @@ describe("policy preset builders", () => {
     test("custom reason works", () => {
       const rule = requireApproval(["payment"], "needs CFO sign-off");
       assert.equal(rule.reason, "needs CFO sign-off");
+    });
+  });
+
+  describe("requireToolApproval", () => {
+    const toolCallCtx = (tool: string): EnforcementContext => ({
+      agentId: "agent-1",
+      action: "tool_call",
+      tool,
+    });
+
+    test("creates rule with require_approval outcome", () => {
+      assert.equal(requireToolApproval(["linear_create_task_task"]).outcome, "require_approval");
+    });
+
+    test("uses tool_match condition carrying the tool list", () => {
+      const rule = requireToolApproval(["linear_create_task_task", "send_email"]);
+      assert.equal(rule.condition.type, "tool_match");
+      assert.deepEqual(rule.condition.params.tools, ["linear_create_task_task", "send_email"]);
+    });
+
+    test("id includes tool names", () => {
+      const rule = requireToolApproval(["a", "b"]);
+      assert.equal(rule.id, "require-tool-approval-a-b");
+    });
+
+    test("priority is 80", () => {
+      assert.equal(requireToolApproval(["x"]).priority, 80);
+    });
+
+    test("custom reason works", () => {
+      const rule = requireToolApproval(["x"], "needs sign-off");
+      assert.equal(rule.reason, "needs sign-off");
+    });
+
+    // PRO-257 regression: the runtime always evaluates action "tool_call"
+    // with the tool name in ctx.tool — the rule must match on ctx.tool.
+    test("evaluator yields require_approval for a tool_call of a listed tool", () => {
+      const engine = createPolicyEngine({
+        rules: [requireToolApproval(["linear_create_task_task"])],
+      });
+      const decision = engine.evaluate(toolCallCtx("linear_create_task_task"));
+      assert.equal(decision.outcome, "require_approval");
+      assert.equal(decision.blocked, true);
+      assert.equal(decision.ruleId, "require-tool-approval-linear_create_task_task");
+    });
+
+    test("evaluator does not fire for unlisted tools", () => {
+      const engine = createPolicyEngine({
+        rules: [requireToolApproval(["linear_create_task_task"])],
+      });
+      const decision = engine.evaluate(toolCallCtx("web_search"));
+      assert.equal(decision.outcome, "allow");
+      assert.equal(decision.ruleId, null);
+    });
+
+    test("evaluator does not fire when ctx.tool is absent", () => {
+      const engine = createPolicyEngine({
+        rules: [requireToolApproval(["linear_create_task_task"])],
+      });
+      const decision = engine.evaluate({ agentId: "agent-1", action: "tool_call" });
+      assert.equal(decision.outcome, "allow");
+    });
+
+    test("requireApproval action_type semantics are unchanged", () => {
+      const engine = createPolicyEngine({ rules: [requireApproval(["payment"])] });
+      const payment = engine.evaluate({ agentId: "agent-1", action: "payment" });
+      assert.equal(payment.outcome, "require_approval");
+      // A tool_call whose tool name happens to be "payment" is NOT an
+      // action of type "payment" — action_type still gates action categories.
+      const toolCall = engine.evaluate(toolCallCtx("payment"));
+      assert.equal(toolCall.outcome, "allow");
     });
   });
 

--- a/packages/governance/src/policy-presets.ts
+++ b/packages/governance/src/policy-presets.ts
@@ -84,6 +84,35 @@ export function requireApproval(actions: PolicyAction[], reason?: string): Polic
 }
 
 /**
+ * Require human approval for specific tools, matched by name against the
+ * runtime `ctx.tool` field. Use this — not `requireApproval` — when the
+ * approval list is a set of tool names: `requireApproval` gates action
+ * *categories* (`ctx.action`, e.g. "payment"), and runtime tool calls
+ * always evaluate as `action: "tool_call"` with the tool name in `ctx.tool`.
+ *
+ * @param tools - Tool names that need human review before execution
+ * @param reason - Optional custom reason message
+ * @returns A PolicyRule with outcome "require_approval"
+ *
+ * @example
+ * ```ts
+ * const rule = requireToolApproval(['linear_create_task_task', 'send_email']);
+ * ```
+ */
+export function requireToolApproval(tools: string[], reason?: string): PolicyRule {
+  return {
+    id: `require-tool-approval-${tools.join("-")}`,
+    name: `Require approval for tools: ${tools.join(", ")}`,
+    condition: { type: "tool_match", params: { tools } },
+    outcome: "require_approval",
+    reason: reason ?? `Tool requires human approval: ${tools.join(", ")}`,
+    priority: 80,
+    enabled: true,
+    stage: "process",
+  };
+}
+
+/**
  * Enforce a per-session token budget. Blocks when sessionTokensUsed exceeds maxTokens.
  *
  * @param maxTokens - Maximum tokens allowed per session

--- a/packages/governance/src/policy-stage-defaults.ts
+++ b/packages/governance/src/policy-stage-defaults.ts
@@ -16,6 +16,7 @@ const STAGE_MAP: Record<string, PolicyStage> = {
   // Process — run during execution (default)
   tool_blocked: "process",
   tool_allowed: "process",
+  tool_match: "process",
   action_type: "process",
   agent_level: "process",
   require_signed_identity: "process",

--- a/packages/governance/src/policy.ts
+++ b/packages/governance/src/policy.ts
@@ -487,6 +487,7 @@ export {
   blockTools,
   allowOnlyTools,
   requireApproval,
+  requireToolApproval,
   tokenBudget,
   rateLimit,
   requireLevel,


### PR DESCRIPTION
Superseded — replaced by a follow-up PR from a renamed branch.