### PR TITLE
security: js-yaml ^4.3.1 (dependabot)

### DIFF
--- a/examples/demo-app/package-lock.json
+++ b/examples/demo-app/package-lock.json
@@ -2107,9 +2107,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/examples/demo-app/package.json
+++ b/examples/demo-app/package.json
@@ -29,7 +29,7 @@
     "vite": "^8.1.0"
   },
   "overrides": {
-    "js-yaml@4": "4.3.0",
+    "js-yaml@4": "^4.3.1",
     "brace-expansion@1": "1.1.16",
     "brace-expansion@5": "5.0.7",
     "postcss@8": "^8.5.18"


### PR DESCRIPTION
Addresses Dependabot alert #29: js-yaml >=4.0.0 <4.3.1.

The nested `examples/demo-app/` has its OWN package-lock.json not covered by the root override. Bumped the demo-app override `js-yaml@4` from `4.3.0` to `^4.3.1` and regenerated the lockfile surgically (`npm install --package-lock-only`).

- Resolved js-yaml: 4.3.1
- Lockfile diff touches js-yaml only
- No 3.x js-yaml present; no other nested manifest references js-yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)